### PR TITLE
Replace the preboot uboot variable to unlock the stick with the correct one from the manufacturer

### DIFF
--- a/_ont/ont-fs-com-gpon-onu-stick-with-mac.md
+++ b/_ont/ont-fs-com-gpon-onu-stick-with-mac.md
@@ -98,18 +98,18 @@ sfp_i2c -i10 -s "password01"
 
 ## Setting eqipment id (ME 257)
 ```sh
-sfp_i2c -i6 -s "22133912P"
+sfp_i2c -i6 -s "YOUR_EQUIPMENT_ID"
 ```
 
 ## Setting vendor id (ME 256)
 ```sh
-sfp_i2c -i7 -s "SPGA"
+sfp_i2c -i7 -s "YOUR_VENDOR_ID"
 ```
 
 ## Change ONU hardware version (ME 256)
 ```sh
 cp /etc/mibs/data_1g_8q.ini /etc/mibs/data_1g_8q.ini.bak
-sed 's/256 0 HWTC 0000000000000/256 0 <your_vendor_id> <your_onu_version>/' /etc/mibs/data_1g_8q.ini
+sed 's/256 0 HWTC 0000000000000/256 0 YOUR_VENDOR_ID YOUR_ONU_VERSION/' -i /etc/mibs/data_1g_8q.ini
 ```
 
 ## Change image software version (ME 7)
@@ -142,8 +142,8 @@ bspatch <your_original_omcid> omcid omcid.bspath
 
 Now you have to copy via SCP the modified `omcid` binary in the `/opt/lantiq/bin/omcid` path, restart the stick and after that you can change the image version with the command:
 ```
-fw_setenv image0_version <your_image0_version>
-fw_setenv image1_version <your_image1_version>
+fw_setenv image0_version YOUR_IMAGE0_VERSION
+fw_setenv image1_version YOUR_IMAGE1_VERSION
 ```
 
 

--- a/_ont/ont-fs-com-gpon-onu-stick-with-mac.md
+++ b/_ont/ont-fs-com-gpon-onu-stick-with-mac.md
@@ -50,7 +50,7 @@ layout: default
 ```sh
 fw_setenv bootdelay 5
 fw_setenv asc0 0
-fw_setenv preboot "gpio input 105;gpio input 106;gpio input 107;gpio input 108;gpio set 3;gpio set 109;gpio set 110;gpio clear 423;gpio clear 422;gpio clear 325;gpio clear 402;gpio clear 424"
+fw_setenv preboot "gpio set 3;gpio input 2;gpio input 105;gpio input 106;gpio input 107;gpio input 108"
 ```
 If you haven't done this and the stick doesn't work due to your changes you can follow the [Huawei MA5671A unlock guide](/ont-huawei-ma5671a-root)
 

--- a/_ont/ont-fs-com-gpon-onu-stick-with-mac.md
+++ b/_ont/ont-fs-com-gpon-onu-stick-with-mac.md
@@ -112,6 +112,23 @@ cp /etc/mibs/data_1g_8q.ini /etc/mibs/data_1g_8q.ini.bak
 sed 's/256 0 HWTC 0000000000000/256 0 YOUR_VENDOR_ID YOUR_ONU_VERSION/' -i /etc/mibs/data_1g_8q.ini
 ```
 
+## Enable `data_1g_8q_us1280_ds512.ini` OMCI MIB file for 2500 Mbps profiles
+{% include alert.html content="The patch below is only compatible with the firmware version `6BA1896SPLQA42`" alert="Info" icon="svg-info" color="blue" %}
+{% include alert.html content="If you need to set the ONU version remember that you will have to do it using the MIB file `/etc/mibs/data_1g_8q_us1280_ds512.ini` instead of `/etc/mibs/data_1g_8q.ini`" alert="Info" icon="svg-info" color="blue" %}
+
+The MIB file `data_1g_8q_us1280_ds512.ini` is very useful to avoid performance problems in situations where 2500 Mbps speed profiles are used, to enable it you need to run this command:
+```sh
+fw_setenv mib_file data_1g_8q_us1280_ds512.ini
+```
+
+## Use custom OMCI MIB file
+{% include alert.html content="If you need to set the ONU version remember that you will have to do it using your custom MIB file instead of `/etc/mibs/data_1g_8q.ini`" alert="Info" icon="svg-info" color="blue" %}
+
+You have to copy the MIB file to /etc/mibs and then run this command:
+```sh
+fw_setenv mib_file YOUR_MIB_FILENAME
+```
+
 ## Change image software version (ME 7)
 {% include alert.html content="The patch below is only compatible with the firmware version `6BA1896SPLQA42`" alert="Info" icon="svg-info" color="blue" %}
 

--- a/_ont/ont-fs-com-gpon-onu-stick-with-mac.md
+++ b/_ont/ont-fs-com-gpon-onu-stick-with-mac.md
@@ -96,15 +96,56 @@ sfp_i2c -i9 -s "1234567890"
 sfp_i2c -i10 -s "password01"
 ```
 
-## Setting eqipment id
+## Setting eqipment id (ME 257)
 ```sh
 sfp_i2c -i6 -s "22133912P"
 ```
 
-## Setting vendor id
+## Setting vendor id (ME 256)
 ```sh
 sfp_i2c -i7 -s "SPGA"
 ```
+
+## Change ONU hardware version (ME 256)
+```sh
+cp /etc/mibs/data_1g_8q.ini /etc/mibs/data_1g_8q.ini.bak
+sed 's/256 0 HWTC 0000000000000/256 0 <your_vendor_id> <your_onu_version>/' /etc/mibs/data_1g_8q.ini
+```
+
+## Change image software version (ME 7)
+{% include alert.html content="The patch below is only compatible with the firmware version `6BA1896SPLQA42`" alert="Info" icon="svg-info" color="blue" %}
+
+The image version normally couldn't be changed because it was hard-coded into the `/opt/lantiq/bin/omcid` binary, 
+so you need to then modify the binary with the following hex patch which removes the hardcoded version.
+
+```
+< 000084c0: 9a43 931f f760 d840 9b64 f760 d864 1a00  .C...`.@.d.`.d..
+< 000084d0: 1acf 6500 1a20 2268 940a 2205 b468 1a00  ..e.. "h.."..h..
+---
+> 000084c0: 9a43 931f f760 d840 9b64 f760 d864 6500  .C...`.@.d.`.de.
+> 000084d0: 6500 6500 1a20 2268 940a 2205 b468 1a00  e.e.. "h.."..h..
+
+```
+
+To make it easier you can use the following base64:
+```
+QlNESUZGNDA1AAAAAAAAAD4AAAAAAAAA2C8JAAAAAABCWmg5MUFZJlNZYqnvBwAACFBSQWAAAMAA
+AAgAQCAAMQwIIwjImgDOdMvi7kinChIMVT3g4EJaaDkxQVkmU1lrJSbUAACFTAjAACAAAAiCAAAI
+IABQYAFKQ01INxUgd6Soj2JURm8pUR8XckU4UJBrJSbUQlpoORdyRThQkAAAAAA=
+```
+
+Save it as `omcid_patch.base64`, then run:
+```
+base64 -d omcid_patch.base64 > omcid.bspath
+bspatch <your_original_omcid> omcid omcid.bspath
+```
+
+Now you have to copy via SCP the modified `omcid` binary in the `/opt/lantiq/bin/omcid` path, restart the stick and after that you can change the image version with the command:
+```
+fw_setenv image0_version <your_image0_version>
+fw_setenv image1_version <your_image1_version>
+```
+
 
 ## Setting Lantiq MAC address
 ```sh

--- a/_ont/ont-huawei-ma5671a-root.md
+++ b/_ont/ont-huawei-ma5671a-root.md
@@ -66,7 +66,7 @@ try:
             time.sleep(1)
             print('[+] Transfer command sequence 4')
             ser.write(
-                'setenv preboot "gpio input 105;gpio input 106;gpio input 107;gpio input 108;gpio set 3;gpio set 109;gpio set 110;gpio clear 423;gpio clear 422;gpio clear 325;gpio clear 402;gpio clear 424"\n'.encode())
+                'gpio set 3;gpio input 2;gpio input 105;gpio input 106;gpio input 107;gpio input 108"\n'.encode())
             time.sleep(1)
             print('[+] Transfer command sequence 5')
             ser.write('saveenv\n'.encode())

--- a/_ont/ont-tplink-xz000-g3.md
+++ b/_ont/ont-tplink-xz000-g3.md
@@ -1,0 +1,35 @@
+---
+title: TP-Link XZ000-G3
+has_children: false
+layout: default
+---
+
+# Hardware Specifications
+
+|             |                                       |
+| ----------- | ------------------------------------- |
+| Vendor      | TP-Link                               |
+| Model       | XZ000-G3                              |
+| Chipset     |                                       |
+| CPU         | MIPS32                                |
+| Flash       |                                       |
+| RAM         |                                       |
+| System      | TCLinux                               |
+| HSGMII      | NO                                    |
+| Optics      | SC/APC                                |
+| IP address  | 192.168.1.1                           |
+| Web Gui     | ✅ username `admin`, password `admin` |
+| SSH         |                                       |
+| Form Factor | ONT                                   |
+
+
+## List of software versions
+## List of partitions
+## List of firmwares and files
+
+# Known Bugs
+
+The ONT randomly crashes when PPPoE connection is established
+
+The GPON serial sometimes temporarily disappears after a crash preventing the ONT from reaching O5
+


### PR DESCRIPTION
Actually the preboot variable that we use to unlock the serial number of the Lantiq Falcon SFP sticks is not correct.

We currently use the following string to unlock the serial:
```
gpio input 105;gpio input 106;gpio input 107;gpio input 108;gpio set 3;gpio set 109;gpio set 110;gpio clear 423;gpio clear 422;gpio clear 325;gpio clear 402;gpio clear 424
```

But that doesn't make any sense, the manufacturer uses the following variables:

- Serial locked:
```
gpio set 3;gpio input 100;gpio input 105;gpio input 106;gpio input 107;gpio input 108
```

- Serial unlocked:
```
gpio set 3;gpio input 2;gpio input 105;gpio input 106;gpio input 107;gpio input 108
```

With this PR I change the string we have always used with the correct one from the manufacturer, there doesn't seem to be any practical difference with this replacement.

I'm not sure if it's useful to merge this PR since there doesn't seem to be any differences but I decided to open it to preserve this detail regarding the preboot variable, **probably we need to think carefully before merging to avoid regressions**.