### PR TITLE
Fix DIGITUS media converter aliases

### DIFF
--- a/_sfp_cage/digitus-10gbps-dn-82211.md
+++ b/_sfp_cage/digitus-10gbps-dn-82211.md
@@ -1,7 +1,7 @@
 ---
 title: DIGITUS 10Gbps DN-82211
 has_children: false
-alias: HPE 530SFP+, DELL N20KJ
+alias:
 layout: default
 ---
 


### PR DESCRIPTION
The aliases I removed are just for Broadcom 57810S, not the DIGITUS media converter.