### PR TITLE
FS: Removed useless Vendor ID for setting hardware version

### DIFF
--- a/_ont/ont-fs-com-gpon-onu-stick-with-mac.md
+++ b/_ont/ont-fs-com-gpon-onu-stick-with-mac.md
@@ -196,7 +196,7 @@ sfp_i2c -i7 -s "YOUR_VENDOR_ID"
 
 ## Changing ONU hardware version (ME 256)
 ```sh
-sed 's/256 0 HWTC 0000000000000/256 0 YOUR_VENDOR_ID YOUR_ONU_VERSION/' /rom/etc/mibs/data_1g_8q.ini > /etc/mibs/data_1g_8q.ini
+sed 's/256 0 HWTC 0000000000000/256 0 HWTC YOUR_ONU_VERSION/' /rom/etc/mibs/data_1g_8q.ini > /etc/mibs/data_1g_8q.ini
 ```
 
 ## Restore the default ONU hardware version (ME 256)


### PR DESCRIPTION
The Vendor ID is in any case replaced with the one present in the EEPROM and possibly set with `sfp_i2c -i7 -s "YOUR_VENDOR_ID"`, so it's totally useless to specify in the MIB file and causes unnecessary confusion