### PR TITLE
Update about Serial (Sercomm FG1000B.11)

### DIFF
--- a/_ont/ont-sercomm-fg1000b-11.md
+++ b/_ont/ont-sercomm-fg1000b-11.md
@@ -26,7 +26,7 @@ parent: Sercomm
 | Web Gui         | ✅, no login needed    |
 | SSH             | No                     |
 | Telnet          | No                     |
-| Serial          | No                     |
+| Serial          | ✅, only TX            |
 | Serial baud     | 115200                 |
 | Serial encoding | 8-N-1                  |
 | Form Factor     | ONT                    |


### PR DESCRIPTION
I noticed I missed the Serial as No because I was thinking login/password but there is a serial on the device which is shown on the picture. Particularity is it seems only to send TX data but not allow RX at CFE boot time.