### PR TITLE
rootLantiq: Fix BREAK received on FTDI using Uint8Array directly

### DIFF
--- a/assets/js/serialUtil.js
+++ b/assets/js/serialUtil.js
@@ -19,6 +19,100 @@ class LineBreakTransformer {
     }
 }
 
+class SerialReadWrite {
+    constructor(port, baudrate) {
+        this.port = port;
+        this.baudRate = baudrate;
+        this.isPortOpen = false;
+        this.textDecoder = new TextDecoder();
+        this.textEncoder = new TextEncoder();
+    }
+
+    async openPort() {
+        await this.port.open({ baudRate: this.baudRate });
+    }
+
+    async closePort() {
+        await this.port.close();
+    }
+
+    async readLine(readCallback, timeout = undefined) {
+        let reader = undefined;
+        let extraChunk = "";
+
+        if (this.isPortOpen === false) {
+            await this.openPort();
+            this.isPortOpen = true;
+        }
+
+        while (true) {
+            try {
+                if (reader === undefined) {
+                    reader = this.port.readable.getReader();
+                }
+
+                let serialValue;
+                if (timeout === undefined) {
+                    const { value, done } = await reader.read();
+                    serialValue = value;
+                } else {
+                    const { value, done } = await Promise.race([
+                        reader.read(),
+                        new Promise((_, reject) => setTimeout(reject, timeout, new Error("timeout")))
+                    ]);
+                    serialValue = value;
+                }
+
+                const linesValue = this.textDecoder.decode(serialValue).split('\n');
+                linesValue[0] = extraChunk + linesValue[0];
+                extraChunk = linesValue[linesValue.length - 1];
+
+                for (const line of linesValue) {
+                    if (readCallback(line) === true) {
+                        return;
+                    }
+                }
+            } catch (e) {
+                if (e instanceof DOMException &&
+                    (e.name === "BreakError" || e.name === "FramingError" || e.name === "ParityError")) {
+                    console.log(e);
+                } else if (e instanceof Error && e.message === "timeout") {
+                    return;
+                } else {
+                    throw e;
+                }
+            } finally {
+                if (reader) {
+                    reader.releaseLock();
+                    reader = undefined;
+                }
+            }
+        }
+    }
+
+    async writeString(str) {
+        let writer = undefined;
+
+        if (this.isPortOpen === false) {
+            await this.openPort();
+            this.isPortOpen = true;
+        }
+
+        try {
+            if (writer === undefined) {
+                writer = this.port.writable.getWriter();
+            }
+
+            writer.write(textEncoder.encode(str));
+        } finally {
+            if (writer) {
+                writer.releaseLock();
+                writer = undefined;
+            }
+        }
+    }
+}
+
 async function openPortLineBreak(port, baudRate) {
     await port.open({ baudRate: baudRate });
     const textDecoder = new TextDecoderStream();


### PR DESCRIPTION
I rewrote pretty much all of the first stage root process for Lantiq, by using the reader/writer directly with Uint8Array it is possible to reopen the reader when he receives the BREAK event.

This fixes the root process compatibility issues with TTL-USB with FTDI chip, it is not strictly necessary to rewrite the other phases of the process since the BREAK event occurs only when the user connects the SFP and consequently only the first phase is affected by the problem nevertheless it would be better to do it as the code is more reliable if done correctly.

