### PR TITLE
Update OMCI_OLT_MODE and LAN_SDS_MODE for realtek

### DIFF
--- a/_ont/ont-carlitoxxpro-cpgos03-0490-v2.md
+++ b/_ont/ont-carlitoxxpro-cpgos03-0490-v2.md
@@ -30,7 +30,10 @@ parent: CarlitoxxPro
 
 - You should use the VID/VLAN shown by executing the command `omcicli mib get 84` via telnet to bring up PPPoE
 
-{% include_relative ont-luna-sdk-useful-commands.md flash='flash' ploam='asciiAndHex' %}
+{% include_relative ont-luna-sdk-useful-commands.md 
+    flash='flash' 
+    ploam='asciiAndHex' 
+%}
 
 
 # Miscellaneous Links

--- a/_ont/ont-leox-lxt-010g-d.md
+++ b/_ont/ont-leox-lxt-010g-d.md
@@ -30,4 +30,9 @@ parent: LEOX
 
 The ONT has a TTL 3.3v UART console (configured as 115200 8-N-1) that can be accessed from the top surface.
 
-{% include_relative ont-luna-sdk-useful-commands.md ploam='ascii' flash='/etc/scripts/flash' %}
+{% include_relative ont-luna-sdk-useful-commands.md 
+    ploam='ascii'
+    flash='/etc/scripts/flash'
+    customSwVersionAlert='This needs the `OMCI_OLT_MODE` value to be set to `21`. This will force to use your own settings from the XML file, but this is a hack and causes sigsegv of `/bin/checkomci`.'
+    omciOLT21='true'
+%}

--- a/_ont/ont-leox-lxt-010h-d.md
+++ b/_ont/ont-leox-lxt-010h-d.md
@@ -70,6 +70,11 @@ This ONT supports dual boot.
 
 {% include alert.html content="Before proceed on any modification, make a backup of files rtl8290b.data and europa.data from /var/config folder. These files include optical calibration of your ONT's laser, if you accidentally delete or ruin them, your ONT will be unusable" alert="Note" icon="svg-warning" color="yellow" %}
 
-{% include_relative ont-luna-sdk-useful-commands.md ploam='ascii' flash='/etc/scripts/flash' customSwVersionAlert='This needs the OMCI_OLT_MODE value to be set to 21' omciOLT21='true' %}
+{% include_relative ont-luna-sdk-useful-commands.md 
+    ploam='ascii'
+    flash='/etc/scripts/flash'
+    customSwVersionAlert='This needs the `OMCI_OLT_MODE` value to be set to `21`. This will force to use your own settings from the XML file, but this is a hack and causes sigsegv of `/bin/checkomci`.'
+    omciOLT21='true'
+%}
 
 

--- a/_ont/ont-leox-lxt-010s-h.md
+++ b/_ont/ont-leox-lxt-010s-h.md
@@ -68,7 +68,13 @@ The stick has a TTL 3.3v UART console (configured as 115200 8-N-1) that can be a
 - V3.3.4L4rc1 (Fix 2.5GbE HiSGMII)
 - V3.3.4L4rc5
 
-{% include_relative ont-luna-sdk-useful-commands.md ploam='ascii' speedLan='178' customSpeedLanAlert='You need firmware `V3.3.4L4rc1` or higher. Before editing the speed make sure your hardware supports it. If you try to use any mode not listed here, stick will default to mode 1.' flash='/etc/scripts/flash' customSwVersionAlert='This needs the OMCI_OLT_MODE value to be set to 21' omciOLT21='true' %}
+{% include_relative ont-luna-sdk-useful-commands.md 
+    ploam='ascii'
+    speedLan='18'
+    customSpeedLanAlert='You need firmware `V3.3.4L4rc1` or higher. Before editing the speed make sure your hardware supports it. If you try to use any mode not listed here, stick will default to mode 1.'
+    flash='/etc/scripts/flash'
+    customSwVersionAlert='This needs the `OMCI_OLT_MODE` value to be set to `21`. This will force to use your own settings from the XML file, but this is a hack and causes sigsegv of `/bin/checkomci`.'
+    omciOLT21='true' %}
 
 # Known Bugs
 

--- a/_ont/ont-luna-sdk-useful-commands.md
+++ b/_ont/ont-luna-sdk-useful-commands.md
@@ -100,8 +100,12 @@ GPON_PLOAM_PASSWD=AAAAAAAAAA
 
 ## Getting/Setting OMCI software version (ME 7)
 
-{% assign customSwVersionAlert = include.customSwVersionAlert | default: "This needs the `OMCI_OLT_MODE` value to be set to 3" %}
+{% if include.customSwVersionAlert %}
+
+{% assign customSwVersionAlert = include.customSwVersionAlert %}
 {% include alert.html content=customSwVersionAlert alert="Note" icon="svg-info" color="blue" %}
+
+{% endif %}
 
 {% if include.flashSwVersion %}
 ```sh
@@ -121,8 +125,12 @@ OMCI_SW_VER1=YOURSECONDSWVER
 
 ## Getting/Setting OMCI hardware version (ME 256)
 
-{% assign customHwVersionAlert = include.customHwVersionAlert | default: "This needs the `OMCI_OLT_MODE` value to be set to 3" %}
+{% if include.customHwVersionAlert %}
+
+{% assign customHwVersionAlert = include.customHwVersionAlert %}
 {% include alert.html content=customHwVersionAlert alert="Note" icon="svg-info" color="blue" %}
+
+{% endif %}
 
 ```sh
 # {{ include.flash }} get HW_HWVER
@@ -132,8 +140,12 @@ HW_HWVER=V2.0
 
 ## Getting/Setting OMCI vendor ID (ME 256)
 
-{% assign customVendorAlert = include.customVendorAlert | default: "This needs the `OMCI_OLT_MODE` value to be set to 3" %}
+{% if include.customVendorAlert %}
+
+{% assign customVendorAlert = include.customVendorAlert %}
 {% include alert.html content=customVendorAlert alert="Note" icon="svg-info" color="blue" %}
+
+{% endif %}
 
 ```sh
 # {{ include.flash }} get PON_VENDOR_ID  
@@ -143,8 +155,12 @@ PON_VENDOR_ID=ZTEG
 
 ## Getting/Setting OMCI equipment ID (ME 257)
 
-{% assign customEquipAlert = include.customEquipAlert | default: "This needs the `OMCI_OLT_MODE` value to be set to 3" %}
+{% if include.customEquipAlert %}
+
+{% assign customEquipAlert = include.customEquipAlert %}
 {% include alert.html content=customEquipAlert alert="Note" icon="svg-info" color="blue" %}
+
+{% endif %}
 
 ```sh
 # {{ include.flash }} get GPON_ONU_MODEL

--- a/_ont/ont-odi-realtek-dfp-34g-2c2.md
+++ b/_ont/ont-odi-realtek-dfp-34g-2c2.md
@@ -70,7 +70,13 @@ The stick has a TTL 3.3v UART console (configured as 115200 8-N-1) that can be a
 
 {% include alert.html content="Some USB TTL adapters label TX and RX pins the other way around: try to swap them if the connection doesn't work." alert="Note"  icon="svg-warning" color="yellow" %}
 
-{% include_relative ont-luna-sdk-useful-commands.md flash='flash' ploam='hex' customSwVersionAlert="This needs the `OMCI_OLT_MODE` value to be set to 3 and firmware 220530 or 220923 modded by @stich86 or if you don't want to replace firmware to change software version, set `OMCI_OLT_MODE` value to `21`. This will force to use your own settings from the XML file, but this is a hack and causes sigsegv of `/bin/checkomci`" speedLan='1234567' omciOLT21='true' %}
+{% include_relative ont-luna-sdk-useful-commands.md 
+    flash='flash' 
+    ploam='hex' 
+    customSwVersionAlert="This needs the `OMCI_OLT_MODE` value to be set to 3 and firmware 220530 or 220923 modded by @stich86 or if you don't want to replace firmware to change software version, set `OMCI_OLT_MODE` value to `21`. This will force to use your own settings from the XML file, but this is a hack and causes sigsegv of `/bin/checkomci`." 
+    speedLan='1234567' 
+    omciOLT21='true'
+%}
 
 # Known Bugs
 

--- a/_ont/ont-odi-realtek-dfp-34x-2c2.md
+++ b/_ont/ont-odi-realtek-dfp-34x-2c2.md
@@ -79,7 +79,13 @@ The stick has a TTL 3.3v UART console (configured as 115200 8-N-1) that can be a
 
 {% include alert.html content="Some USB TTL adapters label TX and RX pins the other way around: try to swap them if the connection doesn't work." alert="Note"  icon="svg-warning" color="yellow" %}
 
-{% include_relative ont-luna-sdk-useful-commands.md flash='flash' ploam='hex' customSwVersionAlert="This needs the `OMCI_OLT_MODE` value to be set to 3 and firmware 220530 or 220923 modded by @stich86 or if you don't want to replace firmware to change software version, set `OMCI_OLT_MODE` value to `21`. This will force to use your own settings from the XML file, but this is a hack and causes sigsegv of `/bin/checkomci`" speedLan='1234567' omciOLT21='true' %}
+{% include_relative ont-luna-sdk-useful-commands.md 
+    flash='flash'
+    ploam='hex'
+    customSwVersionAlert="This needs the `OMCI_OLT_MODE` value to be set to 3 and firmware 220530 or 220923 modded by @stich86 or if you don't want to replace firmware to change software version, set `OMCI_OLT_MODE` value to `21`. This will force to use your own settings from the XML file, but this is a hack and causes sigsegv of `/bin/checkomci`."
+    speedLan='1234567'
+    omciOLT21='true'
+%}
 
 # Known Bugs
 

--- a/_ont/ont-t-w-twcgpon657.md
+++ b/_ont/ont-t-w-twcgpon657.md
@@ -36,7 +36,12 @@ parent: T&W
 
 The reccomended version are `C00R657V2801F_V1.9.0-220404.tar` because it is the V2801F firmware for T&W TWC GPON657.
 
-{% include_relative ont-luna-sdk-useful-commands.md flash='flash' ploam='ascii' speedLan='12345' customSpeedLanAlert='Please use recommended version `C00R657V2801F_V1.9.0-220404.tar`. Before editing the speed make sure your hardware supports it.' %}
+{% include_relative ont-luna-sdk-useful-commands.md 
+    flash='flash'
+    ploam='ascii'
+    speedLan='123456'
+    customSpeedLanAlert='Please use recommended version `C00R657V2801F_V1.9.0-220404.tar`. With other firmware it is not guaranteed that `LAN_SDS_MODE` other than `1` will work. Before editing the speed make sure your hardware supports it.'
+%}
 
 # Known Bugs
 

--- a/_ont/ont-technicolor-afm0002.md
+++ b/_ont/ont-technicolor-afm0002.md
@@ -82,11 +82,15 @@ This stick supports dual boot.
 
 `k0` and `r0` respectively contain the kernel and firmware of the first image, `k1` and `r1` the kernel and firmware of the second one
 
-{% include_relative ont-luna-sdk-useful-commands.md flash='/etc/scripts/flash' ploam='ascii' lastgoodHs=true flashSwVersion=true 
-customSwVersionAlert="This needs the `/etc/scripts/flash` modded"
-customHwVersionAlert="This needs the `/etc/scripts/flash` modded"
-customVendorAlert="This needs the `/etc/scripts/flash` modded"
-customEquipAlert="This needs the `/etc/scripts/flash` modded"
+{% include_relative ont-luna-sdk-useful-commands.md 
+	flash='/etc/scripts/flash'
+	ploam='ascii'
+	lastgoodHs=true
+	flashSwVersion=true 
+	customSwVersionAlert="This needs the `/etc/scripts/flash` modded"
+	customHwVersionAlert="This needs the `/etc/scripts/flash` modded"
+	customVendorAlert="This needs the `/etc/scripts/flash` modded"
+	customEquipAlert="This needs the `/etc/scripts/flash` modded"
 %}
 
 ## Enabling the Web UI

--- a/_ont/ont-technicolor-afm0003.md
+++ b/_ont/ont-technicolor-afm0003.md
@@ -70,7 +70,14 @@ This stick supports dual boot.
 
 `k0` and `r0` respectively contain the kernel and firmware of the first image, `k1` and `r1` the kernel and firmware of the second one
 
-{% include_relative ont-luna-sdk-useful-commands.md flash='/etc/scripts/flash' ploam='ascii' speedLan='12345' customSpeedLanAlert='The defualt firmware does not allow modification of the `LAN_SDS_MODE` parameter. Is it necessary to use the modded firmware. Before editing the speed make sure your hardware supports it.' lastgoodHs=true flashSwVersion=true %}
+{% include_relative ont-luna-sdk-useful-commands.md
+    flash='/etc/scripts/flash'
+    ploam='ascii'
+    speedLan='123456'
+    customSpeedLanAlert='The defualt firmware does not allow modification of the `LAN_SDS_MODE` parameter. Is it necessary to use the modded firmware. Before editing the speed make sure your hardware supports it.'
+    lastgoodHs=true
+    flashSwVersion=true
+%}
 
 ## Enabling the Web UI
 ```sh

--- a/_ont/ont-vsol-v2801f.md
+++ b/_ont/ont-vsol-v2801f.md
@@ -35,7 +35,12 @@ parent: VSOL
 
 The reccomended version are `V2801F_V1.9.0-220425.tar` because it has Modern WebGUI, 2.5GbE, patched `runlansds.sh`, `tftpd`, ...
 
-{% include_relative ont-luna-sdk-useful-commands.md flash='flash' ploam='ascii' speedLan='12345' customSpeedLanAlert='Please use recommended version `V2801F_V1.9.0-220425.tar`. Before editing the speed make sure your hardware supports it.' %}
+{% include_relative ont-luna-sdk-useful-commands.md
+    flash='flash'
+    ploam='ascii'
+    speedLan='123456'
+    customSpeedLanAlert='Please use recommended version `V2801F_V1.9.0-220425.tar`. With other firmware it is not guaranteed that `LAN_SDS_MODE` other than `1` will work. Before editing the speed make sure your hardware supports it.'
+%}
 
 # Known Bugs
 


### PR DESCRIPTION
#267 From our chat it emerged that:

- because for the LEOX in theory all it takes is OLT_MODE 0 (without 3) and changing the two OMCI_SW_VERx
- because otherwise it's wrong on the wiki and people do it about LEOX too
- we should also review the LAN_SDS_MODE because for ODI it is a separate film compared to Technicolor and LEOX (sfp and otherwise)
- the OLT_MODE=3 issue was in theory only for the SW version, everything else almost always changes in any version I think
- at least that's how it is on the LEOX

https://raw.githubusercontent.com/hack-gpon/hack-gpon.github.io/main/_ont/ont-luna-sdk-useful-commands.md