### PR TITLE
ont-zyxel-pmg3000-d20b.md no SSH on firmware  V1.00(ABVJ.1)b1e

### DIFF
--- a/_ont/ont-zyxel-pmg3000-d20b.md
+++ b/_ont/ont-zyxel-pmg3000-d20b.md
@@ -22,7 +22,7 @@ parent: Zyxel
 | HSGMII           | Yes                                                        |
 | Optics           | SC/APC                                                     |
 | IP address       | 10.10.1.1                                                  |
-| Web Gui          | ✅ username `admin` or `guest`, password `1234` or `guest` |
+| Web Gui          | ✅ username `admin` or `guest`, password `1234` or `guest`. Not available in firmware V1.00(ABVJ.1)b1e |
 | SSH              | ✅ username `admin`, password `admin`                      |
 | Telnet           |                                                            |
 | Serial           | ✅                                                         |
@@ -56,6 +56,7 @@ The stick has a TTL 3.3v UART console (configured as 115200 8-N-1) that can be a
 - V1.00(ABVJ.0)b3s (2020)
 - V1.00(ABVJ.0)b3i (2020)
 - V1.00(ABVJ.0)b3v
+- V1.00(ABVJ.1)b1e (ca. 2024)
 - V2.50(ABVJ.0)b1b (2022)
 - V2.50(ABVJ.1)b1d (2023)
 


### PR DESCRIPTION
Added details on V1.00(ABVJ.1)b1e firmware of Zyxel PMG3000-D20B: No SSH shell active.

Open Questions for the V1.00(ABVJ.1)b1e firmware:
1. Is the serial interface still accessible?
2. Will the serial console work if only 3.3 V and GND are connected to respective pins(15,16 and 14+17) of the SFP edge connector?
3. Can the I2C bus at the SFP connector be used to write the GPON Serial to the module? (PLOAM Password can be set as "SLID" in the webinterface.) Maybe it is easier to make one SFP connector with power and I2C instead of an SFP connector for power AND a mechanical adapter for the serial.

Tested on V1.00(ABVJ.1)b1e firmware:
Webinterface is reachable at http://10.10.1.1/
SSH is not reachable. "Network error: Connection refused" (PuTTY), nmap:
```
Starting Nmap 7.95 ( https://nmap.org ) at 2024-12-10 23:53 CET
Nmap scan report for 10.10.1.1
Host is up (0.00067s latency).
Not shown: 999 closed tcp ports (conn-refused)
PORT   STATE SERVICE
80/tcp open  http

Nmap done: 1 IP address (1 host up) scanned in 3.89 seconds
```
