### PR TITLE
avm_fritzbox.md: fw >= 7.50 does not change Modem ID if in Germany

### DIFF
--- a/_router_pon/avm_fritzbox.md
+++ b/_router_pon/avm_fritzbox.md
@@ -10,7 +10,8 @@
 
 ## Setting ONU GPON Serial Number
 
-It was possible to change the serial number ("Modem ID") before firmware version 7.50 by editing it in the http://fritz.box/support.lua, in the ASCII format (ZTEG012345678)
+It is possible to change the serial number ("Modem ID") by editing it in the http://fritz.box/support.lua, in the ASCII format (ZTEG012345678).
+If the Fritz!OS Version is => 7.50 and the device is set up to be in Germany, the field "GPON PLOAM GPON serial number" is missing.
 
 {% include image.html file="avm/avm_serial.jpg"  alt="Serial number form" caption="Serial number form" %}
 

--- a/_router_pon/avm_fritzbox.md
+++ b/_router_pon/avm_fritzbox.md
@@ -10,7 +10,7 @@
 
 ## Setting ONU GPON Serial Number
 
-It is possible to change the serial numebr by editing it in the http://fritz.box/support.lua, in the ASCII format (ZTEG012345678)
+It was possible to change the serial number ("Modem ID") before firmware version 7.50 by editing it in the http://fritz.box/support.lua, in the ASCII format (ZTEG012345678)
 
 {% include image.html file="avm/avm_serial.jpg"  alt="Serial number form" caption="Serial number form" %}
 


### PR DESCRIPTION
AVM removed the field to change the ONU GPON Serial Number, also known as "Modem ID" with firmware version 7.50, at least for Germany.