### PR TITLE
Update ont-zyxel-pmg3000-d20b.md

### DIFF
--- a/_ont/ont-zyxel-pmg3000-d20b.md
+++ b/_ont/ont-zyxel-pmg3000-d20b.md
@@ -22,8 +22,8 @@ parent: Zyxel
 | HSGMII           | Yes                                                        |
 | Optics           | SC/APC                                                     |
 | IP address       | 10.10.1.1                                                  |
-| Web Gui          | ✅ username `admin` or `guest`, password `1234` or `guest`. Not available in firmware V1.00(ABVJ.1)b1e |
-| SSH              | ✅ username `admin`, password `admin`                      |
+| Web Gui          | ✅ username `admin` or `guest`, password `1234` or `guest` |
+| SSH              | ✅ username `admin`, password `admin`. Not available in firmware V1.00(ABVJ.1)b1e |
 | Telnet           |                                                            |
 | Serial           | ✅                                                         |
 | Serial baud      | 115200                                                     |


### PR DESCRIPTION
Corrected the note on the missing web interface for version V1.00(ABVJ.1)b1e. The web interface is still working for this particular verison but dropbear has been removed and so no ssh access is available.