### PR TITLE
ont-ALL-BM410-XGSPON-GBIC: fix link to FS.com ONT

### DIFF
--- a/_ont_xgs/ont-ALL-BM410-XGSPON-GBIC.md
+++ b/_ont_xgs/ont-ALL-BM410-XGSPON-GBIC.md
@@ -28,7 +28,7 @@ parent: ALLNET
 | Form Factor      | miniONT SFP                                                                       |
 
 This SFP module is made by CIG, it also has a CIG MAC address, and is identical
-to the [FS XGS-ONU-25-20NI](ont-fs-XGS-ONU-25-20NI.html).
+to the [FS XGS-ONU-25-20NI](../ont-fs-XGS-ONU-25-20NI/).
 See also its page for further information.
 
 {% include image.html file="ALL-BM410-XGSPON-GBIC/top.jpg" alt="ALL-BM410-XGSPON-GBIC top" caption="ALLNET ALL-BM410-XGSPON-GBIC top" %}


### PR DESCRIPTION
A little fix for #385.
Unfortunately, I only noticed too late that the link to the FS.com page was incorrect in the original PR.