### PR TITLE
Update optical connector info for DFP-34X-2C2

### DIFF
--- a/_ont/ont-odi-realtek-dfp-34x-2c2.md
+++ b/_ont/ont-odi-realtek-dfp-34x-2c2.md
@@ -17,7 +17,7 @@ parent: ODI
 | RAM          | 64 MB                             |
 | System       | Linux (Luna SDK 1.9)              |
 | HSGMII       | Yes                               |
-| Optics       | SC/UPC or SC/APC                  |
+| Optics       | SC/UPC(DFP-34X-2C2), SC/APC(DFP-34X-2C3)|
 | IP address   | 192.168.1.1                       |
 | Web Gui      | ✅ user `admin`, password `admin` |
 | SSH          | ✅ user `admin`, password `admin` |


### PR DESCRIPTION
DFP-34X-2C2 and DFP-34X-2C3 is the same device but with different optics/connector (UPC vs APC).

See https://github.com/Anime4000/RTL960x/issues/310 .