### PR TITLE
feat(epon): F-MDCONU3A — add CLI permission bypass, full command reference, firmware flash protocol

### DIFF
--- a/_ont_epon/free_iliad_F-MDCONU3A.md
+++ b/_ont_epon/free_iliad_F-MDCONU3A.md
@@ -13,14 +13,14 @@ parent: Free/Iliad
 | Model            | F-MDCONU3A                      |
 | ODM              | ✅                              |
 | ODM Product Code |                                 |
-| Chipset          | BCM55030                        |
-| Flash            | W25Q32J (4MB SPI)               |
-| RAM              | embedded                        |
+| Chipset          | BCM55030B2FBG rev B2            |
+| Flash            | W25Q32J (4 MB SPI)              |
+| RAM              | embedded SRAM (DCCM)            |
 | CPU              | ARCompact[^arc-isa], big endian |
 | CPU Clock        |                                 |
-| Bootloader       |                                 |
-| System           |                                 |
-| Load addr        |                                 |
+| Bootloader       | TK2000 Boot v3.27               |
+| System           | bare-metal (no OS)              |
+| Load addr        | 0x20000000 (ICCM)              |
 | HSGMII           | No                              |
 | Optics           | SFP w/o MAC                     |
 | IP address       |                                 |
@@ -32,73 +32,93 @@ parent: Free/Iliad
 | Serial encoding  | 8-N-1                           |
 | Form Factor      | ONT                             |
 
-The BCM55030 is a 10G-EPON ONU/ONT.
-The BCM55030's UNI (User Network Interface) side should be capable of 4xSGMII (1 GbE) or 1xXAUI (10 GbE) or 1xXFI (10 GbE SFP) or 1xRGMII, but only one SGMII lane is actually routed.
-UNI link won't go up when connected to a media converter or directly to a NIC.
+The BCM55030 is a 10G-EPON DPoE (DOCSIS Provisioning over EPON) ONU/ONT used by Free/Iliad (France) on their FTTH network. The PON side operates in asymmetric 10G/1G mode: downstream at 1577 nm / 10.3125 Gb/s, upstream at 1310 nm / 1.25 Gb/s burst (IEEE 802.3av).
+
+The BCM55030's UNI (User Network Interface) side should be capable of 4xSGMII (1 GbE) or 1xXAUI (10 GbE) or 1xXFI (10 GbE SFP) or 1xRGMII, but only one SGMII lane is actually routed (1000BASE-X via soldered SFP+ male connector).
+
+UNI link won't go up when connected to a media converter or directly to a NIC. The firmware waits for a valid 1000BASE-X partner before activating the PON side (circular dependency).
+
+The CPU uses a Harvard architecture: ICCM (Instruction Closely-Coupled Memory) for code execution and DCCM/SRAM for data. Code in ICCM is not readable via the data bus — the `mem/rf` command can only read data memory, not firmware code.
 
 ## Serial
 
 The serial port is easily accessible at TP5 and TP6. A prompt is available without authentication, it is structured as a tree of directories. To navigate type the subdirectory name. To go back type `/` and hit enter. To list available commands type `help`.
 
-Available commands:
+### CLI Permission Levels
+
+The CLI has a 3-level permission system. By default, UART connects at level 0 (restricted). The **`pl`** (Print Level) built-in command switches between levels without any authentication:
+
+| Command      | Level | Effect                                    |
+| ------------ | ----- | ----------------------------------------- |
+| `pl reset`   | 0     | Default restricted access                 |
+| `pl alpha`   | 1     | Debug mode — unlocks ~20 additional commands |
+| **`pl omega`** | **2** | **Full manufacturing access — unlocks ALL commands** |
+
+The `pl` command is a framework built-in keyword (like `help` and `..`) that is processed *before* the permission-checked command tree walk. It never passes through the permission gate, so it works from any level — including the default level 0.
+
+The permission byte is stored at a single RAM address and persists for the duration of the session. It resets to 0 on reboot. To persist a higher level across reboots, use `fds/write` (available at level 1+) to write to FDS group 4, record 7.
+
+### Available commands
+
+Level 0 (default — 22 root entries, ~60 total commands):
 
 ```
 - mac/
-	- epon
-	- user
+    - epon
+    - user
 - alm/
-	- info
-	- gpio
+    - info
+    - gpio
 - debug/
-	- mcast
-	- mpcp
-	- nco
-	- rstp
-	- sysd
+    - mcast
+    - mpcp
+    - nco
+    - rstp
+    - sysd
 - epon/
-	- eponmac
-	- usermac
-	- dom
-	- ponspeed
+    - eponmac
+    - usermac
+    - dom
+    - ponspeed
 - fds/
-	- erase
+    - erase
 - load/
-	- info
-	- commit
-	- setRecoveryPoint
-	- runRecoveryPoint
-	- rx
+    - info
+    - commit
+    - setRecoveryPoint
+    - runRecoveryPoint
+    - rx
 - mcast/
-	- domains
-	- groups
-	- sources
-	- reporters
-	- igmpinfo
-	- igmpsources
+    - domains
+    - groups
+    - sources
+    - reporters
+    - igmpinfo
+    - igmpsources
 - mem/
-	- rf
+    - rf
 - mpcp/
-	- info
-	- failsafe
-	- oltmac
+    - info
+    - failsafe
+    - oltmac
 - pers/
-	- read
+    - read
 - serdes/
-	- sdextlptest
+    - sdextlptest
 - stats/
-	- clear
-	- gather
-	- epon
-	- fifo
-	- lif
-	- uni
-	- xif
-	- statsmode
+    - clear
+    - gather
+    - epon
+    - fifo
+    - lif
+    - uni
+    - xif
+    - statsmode
 - log/
-	- show
-	- level
+    - show
+    - level
 - sysd/
-	- frmdmp
+    - frmdmp
 - clionly
 - clr
 - ints
@@ -108,6 +128,89 @@ Available commands:
 - echo
 - sftver
 ```
+
+Level 1 (`pl alpha` — adds these commands):
+
+```
+- access/
+    - read          (hardware peripheral bus read — I2C/SPI)
+    - write         (hardware peripheral bus write)
+- mdio/
+    - read
+    - readlst
+    - write
+- lue/
+    - lin/
+        - inst
+    - bin/
+        - inst
+- cust/
+    - e             (examine custom data)
+    - r             (read custom data)
+    - w             (write custom data)
+- fds/
+    - write         (write FDS record)
+- mem/
+    - wm            (write memory)
+    - wf            (write flash)
+    - ef            (erase flash)
+```
+
+Level 2 (`pl omega` — adds these commands):
+
+```
+- efuse             (read eFuse OTP memory)
+- efusebits         (read eFuse bit-level detail)
+- learn/
+    - inst
+    - tbl
+    - age
+    - limit
+- gmc/
+    - le
+    - ld
+- serdes/
+    - dump
+- debug/
+    - fc
+    - epon
+    - learn
+    - eap
+- fifo/
+    - queue
+- eae/
+    - eap
+    - mka
+    - mtime
+    - klen
+- xau/
+    - xcap
+- fec/
+    - auto
+- reglist
+- regbits
+```
+
+### Useful commands
+
+| Command | Description |
+| ------- | ----------- |
+| `sftver` | Print firmware version and chip ID |
+| `load/info` | Show all firmware slots with versions and CRCs |
+| `epon/eponmac` | Show EPON MAC address |
+| `epon/ponspeed` | Show current PON link speed |
+| `mpcp/info` | Show MPCP registration state |
+| `mpcp/oltmac` | Show OLT MAC address |
+| `pers/read` | Dump personality data (raw hex) |
+| `mem/rf <addr> <len>` | Read `len` bytes of data memory starting at `addr` |
+| `stats/epon` | Show EPON statistics counters |
+| `reg <index>` | Read a software register by index |
+| `set <index> <value>` | Write a software register |
+| `pl omega` | Unlock full manufacturing access |
+| `mem/wm <addr> <value>` | Write to memory (level 1+) |
+| `efuse` | Dump eFuse OTP contents (level 2) |
+| `load/rx` | Receive firmware image over UART |
+| `load/commit` | Commit received firmware to active slot |
 
 `load/info` output:
 ```
@@ -158,24 +261,45 @@ Stream: 112 Revision: 131152
 Time: 2016-05-18 01:28:44Z
 ```
 
-`mem/rf [start address] [lenght]` reads bytes from the flash memory, wraps every 512 kB.
+`mem/rf [start address] [length]` reads bytes from data memory (DCCM/SRAM). Due to the Harvard architecture, this command cannot read firmware code (which resides in ICCM). The address space wraps every 512 kB.
+
+## Firmware Flash Protocol
+
+The `load/rx` command accepts a firmware image over UART using a raw binary transfer (no XMODEM, no handshake):
+
+1. Wait for the `2000/>` prompt
+2. Send `load/rx\r`
+3. ONU responds: `Begin binary transfer...`
+4. Send the TKF image as raw binary at 57600 baud (~55 seconds for 319 KB)
+5. ONU responds: `Transfer complete: N bytes received`
+6. Send `load/commit\r` to activate the new slot
+7. Send `reset\r` to reboot
+
+The firmware image must be wrapped in a TKF (Teknovus) container:
+
+```
+[header 39 bytes] [payload N bytes] [CRC32 4 bytes]
+```
+
+The trailing CRC32 covers the entire header+payload (standard IEEE 802.3 CRC). The ONU writes to App 0 and App 1 slots in rotation.
 
 ## List of partitions
 
-The flash memory is not actually partitioned, upon reset the CPU loads from address 0 (reset vector) and jumps to another address ([page 74](http://me.bios.io/images/d/dd/ARCompactISA_ProgrammersReference.pdf#%5B%7B%22num%22%3A177%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C72%2C157%2C0%5D)). Each section ends with its CRC.
+The flash memory (W25Q32J, 4 MB SPI) has 5 regions. Each application section starts with a 39-byte TKF header and ends with its CRC.
 
-| Section               | Start address    | End address      | Size           |
-| --------------------- | ---------------- | ---------------- | -------------- |
-| Bootloader            | 0                | 42896/0xA790     | 42896/0xA790   |
-| App 0                 | ?                | ?                | ?              |
-| App 1                 | 1179687/0x120027 | 1498731/0x16DE6B | 319044/0x4DE44 |
-| App 2                 | 1703975/0x1A0027 | 2023215/0x1EDF2F | 319240/0x4DF08 |
-| Diag (copy of App 1?) | 2555943/0x270027 | 2874987/0x2BDE6B | 319044/0x4DE44 |
+| Section    | Start address    | End address      | Size           | Version |
+| ---------- | ---------------- | ---------------- | -------------- | ------- |
+| Bootloader | 0x000000         | 0x00A790         | 42 KB          | v3.27   |
+| FDS/Config | 0x00A790         | 0x120000         | ~460 KB        | —       |
+| App 1      | 0x120027         | 0x16DE6B         | 319 KB         | v3.2.7  |
+| App 2      | 0x1A0027         | 0x1EDF2F         | 319 KB         | v3.2.9  |
+| Diag       | 0x270027         | 0x2BDE6B         | 319 KB         | v3.2.7  |
 
 (End address is non-inclusive)
-App 1 and App 2 sections are located at a distance of 512 kB (0x80000) from each other. This probably means that the CPU is capable of addressing only 512 kB of flash. It can be verified also by running the `mem/rf` command, which wraps every 512 kB.
 
-# Userful files and binaries
+App slots are located at 512 KB (0x80000) intervals. The CPU can address only 512 KB of flash at a time (verified by `mem/rf` wrapping behavior). The FDS (Flash Data Storage) region between the bootloader and App 1 contains personality records, MAC addresses, SerDes configuration, and CLI config data (34 known FDS record types).
+
+# Useful files and binaries
 
 # EEPROM
 

--- a/_ont_epon/free_iliad_F-MDCONU3A.md
+++ b/_ont_epon/free_iliad_F-MDCONU3A.md
@@ -42,11 +42,11 @@ The CPU uses a Harvard architecture: ICCM (Instruction Closely-Coupled Memory) f
 
 ## Serial
 
-The serial port is easily accessible at TP5 and TP6. A prompt is available without authentication, it is structured as a tree of directories. To navigate type the subdirectory name. To go back type `/` and hit enter. To list available commands type `help`.
+The serial port is easily accessible at TP5 and TP6. A prompt is available without authentication, it is structured as a tree of directories. To navigate type the subdirectory name. To go back type `/` and hit enter. To list available commands type `help` or `?`.
 
 ### CLI Permission Levels
 
-The CLI has a 3-level permission system. By default, UART connects at level 0 (restricted). The **`pl`** (Print Level) built-in command switches between levels without any authentication:
+The CLI has a 3-level permission system. By default, UART connects at level 0 (restricted). The **`pl`** (Permission Level) built-in command switches between levels without any authentication:
 
 | Command      | Level | Effect                                    |
 | ------------ | ----- | ----------------------------------------- |
@@ -58,161 +58,296 @@ The `pl` command is a framework built-in keyword (like `help` and `..`) that is 
 
 The permission byte is stored at a single RAM address and persists for the duration of the session. It resets to 0 on reboot. To persist a higher level across reboots, use `fds/write` (available at level 1+) to write to FDS group 4, record 7.
 
-### Available commands
+### Command tree
 
-Level 0 (default — 22 root entries, ~60 total commands):
+Level 0 (default — ~60 total commands):
 
 ```
 - mac/
-    - epon
-    - user
+    - epon                  show EPON MAC address
+    - user                  show UNI MAC address
 - alm/
-    - info
-    - gpio
+    - info                  show alarm status
+    - gpio                  show GPIO/channel state
 - debug/
-    - mcast
-    - mpcp
-    - nco
-    - rstp
-    - sysd
+    - mcast                 dump active classifier rules
+    - mpcp                  dump MPCP BW queue config
+    - nco                   dump NCO sync state
+    - rstp                  dump debug ring buffer
+    - sysd                  dump system event log
 - epon/
-    - eponmac
-    - usermac
-    - dom
-    - ponspeed
+    - eponmac               show EPON MAC address
+    - usermac               show UNI MAC address
+    - dom                   date of manufacture
+    - ponspeed              get/set PON speed mode
 - fds/
-    - erase
+    - erase                 erase FDS banks 2+3 (⚠️)
 - load/
-    - info
-    - commit
-    - setRecoveryPoint
-    - runRecoveryPoint
-    - rx
+    - info                  show firmware slot info
+    - commit                activate flashed firmware (⚠️)
+    - setRecoveryPoint      mark Diag as recovery
+    - runRecoveryPoint      prepare boot from recovery
+    - rx                    receive firmware over UART (⚠️)
 - mcast/
-    - domains
-    - groups
-    - sources
-    - reporters
-    - igmpinfo
-    - igmpsources
+    - igmpinfo              IGMP snooping state
+    - igmpsources           IGMP SSM sources
 - mem/
-    - rf
+    - rf                    read data memory
 - mpcp/
-    - info
-    - failsafe
-    - oltmac
+    - info                  MPCP registration state
+    - failsafe              get/set failsafe mode
+    - oltmac                show OLT MAC address
 - pers/
-    - read
+    - read                  dump personality data
 - serdes/
-    - sdextlptest
+    - sdextlptest           SerDes loopback test
+    - serdesTestInit        init PRBS test
+    - serdesRx              check SerDes RX status
 - stats/
-    - clear
-    - gather
-    - epon
-    - fifo
-    - lif
-    - uni
-    - xif
-    - statsmode
+    - clear                 reset all counters
+    - gather                trigger counter collection
+    - epon                  EPON MAC counters
+    - fifo                  FIFO/queue counters
+    - lif                   laser interface counters
+    - uni                   UNI port counters
+    - xif                   cross-connect counters
+    - statsmode             get/set counter read mode
 - log/
-    - show
-    - level
+    - show                  show system event log
+    - level                 get/set log verbosity
 - sysd/
-    - frmdmp
-- clionly
-- clr
-- ints
-- reg
-- reset
-- set
-- echo
-- sftver
+    - frmdmp                toggle EPON frame dump
+- clionly                   disable all subsystems except CLI (⚠️)
+- clr                       clear terminal
+- ints                      show interrupt status
+- reg                       read CLI register
+- reset                     full system reset (⚠️)
+- set                       write CLI register
+- echo                      echo text
+- sftver                    show firmware version
 ```
 
-Level 1 (`pl alpha` — adds these commands):
+Level 1 (`pl alpha` — adds these):
 
 ```
 - access/
-    - read          (hardware peripheral bus read — I2C/SPI)
-    - write         (hardware peripheral bus write)
+    - read                  hardware peripheral bus read (I2C/SPI)
+    - write                 hardware peripheral bus write
 - mdio/
-    - read
-    - readlst
-    - write
+    - read                  MDIO PHY register read
+    - readlst               list MDIO registers
+    - write                 MDIO PHY register write
 - lue/
     - lin/
-        - inst
+        - inst              LUE linear lookup
     - bin/
-        - inst
+        - inst              LUE binary lookup
 - cust/
-    - e             (examine custom data)
-    - r             (read custom data)
-    - w             (write custom data)
+    - e                     examine custom data
+    - r                     read custom data
+    - w                     write custom data
 - fds/
-    - write         (write FDS record)
+    - info                  FDS bank status
+    - write                 write FDS record (⚠️)
+    - read                  read specific FDS record
 - mem/
-    - wm            (write memory)
-    - wf            (write flash)
-    - ef            (erase flash)
+    - rm                    read memory (alternate)
+    - wm                    write 32-bit word to memory (⚠️)
+    - wf                    fill memory region (⚠️)
+    - ef                    erase/zero memory region (⚠️)
 ```
 
-Level 2 (`pl omega` — adds these commands):
+Level 2 (`pl omega` — adds these):
 
 ```
-- efuse             (read eFuse OTP memory)
-- efusebits         (read eFuse bit-level detail)
+- efuse                     read eFuse OTP memory
+- efusebits                 read eFuse bit-level detail
 - learn/
-    - inst
-    - tbl
-    - age
-    - limit
+    - dump                  dump MAC learning table
+    - flood                 enable/disable flood mode
+    - switch                enable/disable L2 switching
+    - max                   get/set max MAC entries
+    - apply                 apply config to hardware
 - gmc/
-    - le
-    - ld
+    - le                    multicast config
+    - ld                    multicast config
 - serdes/
-    - dump
+    - sdp                   SerDes PON debug
+    - sdu                   SerDes UNI debug
+    - clk                   SerDes clock config
+    - dump                  dump SerDes debug registers
 - debug/
-    - fc
-    - epon
-    - learn
-    - eap
+    - fc                    flow control debug
+    - epon                  EPON link context dump
+    - learn                 MAC learning engine debug
+    - eap                   EAP-TLS auth debug
 - fifo/
-    - queue
+    - queue                 FIFO queue management
 - eae/
-    - eap
-    - mka
-    - mtime
-    - klen
+    - eap                   EAP MAC address
+    - mka                   MKA protocol state
+    - mtime                 MKA timing parameters
+    - klen                  MACsec key length
 - xau/
-    - xcap
+    - xcap                  10G AU system capture
 - fec/
-    - auto
-- reglist
-- regbits
+    - auto                  FEC auto-negotiation
+- fds/
+    - append                append FDS record (⚠️)
+    - export                export FDS records
+    - copygroup             copy FDS group (⚠️)
+- mem/
+    - tf                    memory test (destructive) (⚠️)
+- reglist                   list all CLI registers
+- regbits                   show register bit fields
 ```
 
-### Useful commands
+### CLI command reference
 
-| Command | Description |
-| ------- | ----------- |
-| `sftver` | Print firmware version and chip ID |
-| `load/info` | Show all firmware slots with versions and CRCs |
-| `epon/eponmac` | Show EPON MAC address |
-| `epon/ponspeed` | Show current PON link speed |
-| `mpcp/info` | Show MPCP registration state |
-| `mpcp/oltmac` | Show OLT MAC address |
-| `pers/read` | Dump personality data (raw hex) |
-| `mem/rf <addr> <len>` | Read `len` bytes of data memory starting at `addr` |
-| `stats/epon` | Show EPON statistics counters |
-| `reg <index>` | Read a software register by index |
-| `set <index> <value>` | Write a software register |
-| `pl omega` | Unlock full manufacturing access |
-| `mem/wm <addr> <value>` | Write to memory (level 1+) |
-| `efuse` | Dump eFuse OTP contents (level 2) |
-| `load/rx` | Receive firmware image over UART |
-| `load/commit` | Commit received firmware to active slot |
+#### System
 
-`load/info` output:
+| Command | Syntax | Description |
+| ------- | ------ | ----------- |
+| `sftver` | `sftver` | Print firmware version, chip ID, and DPoE OAM mode. Output: `2000 0000 v3.2.9 (Rel)` / `DPoE OAM: Off`. Build types: 0=Rel, 1=Custom, 2=Beta, 3=Alpha, 4=Eng. |
+| `reset` | `reset` | Full system reset. Gracefully shuts down EPON link, flushes pending FDS writes, logs the reset event with timestamp, then halts the ARC CPU (aux register 0x28). **The ONU reboots.** |
+| `clionly` | `clionly` | Disable all firmware subsystems (EPON, MPCP, DPoE, MACsec) except CLI UART processing. The ONU becomes non-functional for PON but still responds to commands. Requires `reset` to return to normal. |
+| `clr` | `clr` | Clear terminal screen (ANSI escape). |
+| `echo` | `echo [text]` | Echo text back to UART. |
+| `ints` | `ints` | Dump interrupt controller status: 26 IRQ sources with priority levels (3-bit fields), pending/enable bitmaps, ARC STATUS32 E1/E2 bits. |
+| `reg` | `reg [name]` | Read a CLI framework register by name. Without arguments, lists all registers. These are *software* configuration registers, not hardware MMIO. |
+| `set` | `set <name> <value>` | Write a CLI framework register. Value is a uint8 (0–255). Changes are RAM-only, lost on reboot. |
+| `reglist` | `reglist` | List all CLI framework registers with values. *(Level 2)* |
+| `regbits` | `regbits <name>` | Show a register value with individual bit fields expanded. *(Level 2)* |
+
+#### EPON / MAC
+
+| Command | Syntax | Description |
+| ------- | ------ | ----------- |
+| `epon/eponmac` | `epon/eponmac` | Show the EPON MAC address (6 bytes, no separators). This is the MAC used for MPCP registration. Example: `68A378C25F94`. |
+| `epon/usermac` | `epon/usermac` | Show the UNI-side MAC address. On this ONU, identical to the EPON MAC. |
+| `epon/dom` | `epon/dom [year] [month] [day]` | Get or set the Date of Manufacture. Without args, prints current date. With 3 args, writes the date. Output: `Date of Manufacture: 2020-1-15`. |
+| `epon/ponspeed` | `epon/ponspeed [dnrate uprate [port]]` | Get or set the PON speed mode. Without args, shows current speed/FEC config. `dnrate`: 0=1G, 1=2G, 2=10G. `uprate`: 0=1G, 1=10G. `port` (optional): 0=secondary, 1=primary (default). **Persists to flash (FDS) and triggers full EPON link reinitialization.** Free uses asymmetric 10G/1G = `epon/ponspeed 2 0`. |
+| `mac/epon` | `mac/epon` | Same as `epon/eponmac`. |
+| `mac/user` | `mac/user` | Same as `epon/usermac`. |
+
+#### MPCP
+
+| Command | Syntax | Description |
+| ------- | ------ | ----------- |
+| `mpcp/info` | `mpcp/info` | Show MPCP registration state and slot count. Output is JSON-like: `[[state,slots]]` per LLID. States: 1=WAITING (unregistered), 2=TRANSITION (discovery), 3=REGISTERED. Example: `[[1,32]]` = waiting, 32 slots. |
+| `mpcp/oltmac` | `mpcp/oltmac` | Show the OLT MAC address from the last MPCP registration. `000000000000` = never registered. |
+| `mpcp/failsafe` | `mpcp/failsafe [mode]` | Get or set the MPCP failsafe mode. Controls ONU behavior on registration failure/timeout. Without args, shows current mode. |
+
+#### Memory
+
+| Command | Syntax | Description |
+| ------- | ------ | ----------- |
+| `mem/rf` | `mem/rf <addr> [count]` | Read `count` bytes (default 4) from data memory at `addr`. Address is passed as-is; displayed address adds 0x80000 (cosmetic). Due to Harvard architecture, only reads DCCM/SRAM — cannot read ICCM (firmware code). Wraps every 512 kB. Example: `mem/rf 0x2003e174 4` → `200be174: 09 9b ff ff`. |
+| `mem/wm` | `mem/wm <addr> <value>` | Write a 32-bit word to memory. *(Level 1)* **Direct write to arbitrary address — can corrupt state or crash.** |
+| `mem/wf` | `mem/wf <addr> <value> <count>` | Fill memory region with a value. *(Level 1)* |
+| `mem/ef` | `mem/ef <addr> <count>` | Erase (zero-fill) a memory region. *(Level 1)* |
+| `mem/tf` | `mem/tf <addr> <count>` | Memory test with write/readback patterns. Destructive. *(Level 2)* |
+
+#### Statistics
+
+| Command | Syntax | Description |
+| ------- | ------ | ----------- |
+| `stats/epon` | `stats/epon` | Show EPON MAC counters for all 32 LLIDs (18 TX + 15 RX per LLID) plus 6 global counters. Counters are 64-bit in software mode, 32-bit in register mode. |
+| `stats/uni` | `stats/uni` | Show UNI port counters (PHY1: 50 counters × 4 channels). |
+| `stats/lif` | `stats/lif` | Show laser interface counters (PHY3: 47 counters per channel). All zeros when PON inactive. |
+| `stats/xif` | `stats/xif` | Show cross-connect interface counters (PHY2: 30 counters per channel) plus SerDes config words. |
+| `stats/fifo` | `stats/fifo` | Show FIFO/DMA queue counters with channel occupancy and throughput. |
+| `stats/clear` | `stats/clear` | Reset ALL statistics counters to zero (EPON, PHY, MACsec, channel). Silent on success. |
+| `stats/gather` | `stats/gather [mode]` | Get or set the periodic stats collection mode. Output: `Gather N`. |
+| `stats/statsmode` | `stats/statsmode [mode]` | Get or set counter read mode. 0 = Software (64-bit accumulated buffers), 1 = Register (32-bit direct HW read). Output: `statistic mode 0(Software(64bit))`. |
+
+#### Firmware / Flash
+
+| Command | Syntax | Description |
+| ------- | ------ | ----------- |
+| `load/info` | `load/info` | Show all firmware slots (Boot, App 0/1/2, Diag) with version, size, CRC, build timestamp, and pass/fail status. `pass` = valid CRC, `fail` = bad CRC or empty slot (0xFFFFFFFF). See output example below. |
+| `load/rx` | `load/rx` | Enter raw binary firmware receive mode over UART. See [Firmware Flash Protocol](#firmware-flash-protocol). |
+| `load/commit` | `load/commit` | Activate the most recently flashed firmware by swapping the active bank pointer in FDS. Must be followed by `reset`. |
+| `load/setRecoveryPoint` | `load/setRecoveryPoint` | Mark the Diag slot as a valid recovery point. Verifies CRC first. Output: `OK` or `FAIL`. |
+| `load/runRecoveryPoint` | `load/runRecoveryPoint` | Prepare boot from the recovery point. Output: `Ready to run recovery point, please reset` or `No recovery load to jump to`. Must be followed by `reset`. |
+
+#### FDS (Flash Data Storage)
+
+| Command | Syntax | Description |
+| ------- | ------ | ----------- |
+| `fds/erase` | `fds/erase` | **Erase FDS banks 2 (events) and 3 (provisioning).** Loses DPoE config (VLANs, classifiers) and event history. Bank 0 (firmware) and bank 1 (personality/MAC) are preserved. ONU must be re-provisioned by OLT after reboot. |
+| `fds/info` | `fds/info` | Show FDS bank status (active bank, record count, free space). *(Level 1)* |
+| `fds/read` | `fds/read <group> <record> [sub]` | Read a specific FDS record by group/record/sub IDs. *(Level 1)* |
+| `fds/write` | `fds/write <group> <record> <data...>` | Write data to an FDS record. *(Level 1)* |
+| `fds/export` | `fds/export [group]` | Export FDS records as hex dump. *(Level 2)* |
+
+#### Alarms / Debug
+
+| Command | Syntax | Description |
+| ------- | ------ | ----------- |
+| `alm/info` | `alm/info` | Show current alarm status (MpcpFErr, OnuReset, UniLinkDown, PonPortLos, etc.). |
+| `alm/gpio` | `alm/gpio` | Show GPIO/channel states. On the BCM55030, LEDs are controlled through EPON MAC queue-to-pin mapping, not raw GPIO. |
+| `debug/mpcp` | `debug/mpcp` | Dump MPCP bandwidth queue config for both PON lanes: per-queue VLAN, min/max BW, priority, scheduling mode (Strict/Weighted), total BW. |
+| `debug/mcast` | `debug/mcast` | Dump active DPoE classifier rules (8 slots with rule type, VLAN, priority, match value). |
+| `debug/nco` | `debug/nco` | Dump NCO (Numerically Controlled Oscillator) synchronization state, used for MPCP timestamp generation. |
+| `debug/rstp` | `debug/rstp` | Dump debug ring buffer (32 timestamped event entries). |
+| `debug/sysd` | `debug/sysd` | Dump system event log from FDS. Same as `log/show`. |
+| `debug/epon` | `debug/epon` | Dump full EPON link context: LLID state, encryption, cipher config, MACsec SA. *(Level 2)* |
+| `debug/eap` | `debug/eap` | Dump EAP-TLS authentication state: TLS handshake, certificate, RSA sign. *(Level 2)* |
+| `log/show` | `log/show` | Show system event log with timestamps: MpcpFErr, OnuReset, UniLinkDown, PonPortLos, etc. |
+| `log/level` | `log/level [level]` | Get or set log verbosity level (0–255). Without args, shows current level. Not persistent. |
+
+#### Multicast
+
+| Command | Syntax | Description |
+| ------- | ------ | ----------- |
+| `mcast/igmpinfo` | `mcast/igmpinfo` | Show IGMP snooping state: enabled/disabled, per-group forwarding qualifier, IPv4 flag, group address, SSM domain bitmap, group state, timer values. Supports IGMPv1/v2/v3 and MLDv1/v2 (RFC 3376). |
+| `mcast/igmpsources` | `mcast/igmpsources` | Show IGMP Source-Specific Multicast (SSM) source entries: in-use flag, IPv4 flag, SSM ID, source IP. |
+
+#### Personality
+
+| Command | Syntax | Description |
+| ------- | ------ | ----------- |
+| `pers/read` | `pers/read` | Dump personality data from FDS: 34 records across multiple groups (MAC addresses, serial number, SerDes calibration, crypto certificates, provisioning defaults) + 47 SerDes PHY calibration blocks. Total: ~49 KB. |
+
+#### SerDes
+
+| Command | Syntax | Description |
+| ------- | ------ | ----------- |
+| `serdes/sdextlptest` | `serdes/sdextlptest [lane]` | Run PRBS external loopback test on a SerDes lane (0–3, PON lanes only). Enables loopback, runs test, dumps debug registers (0x60–0x7D), disables loopback. |
+| `serdes/dump` | `serdes/dump` | Dump SerDes debug registers: PON lane (0x70–0x7D) and UNI lane (0x60–0x6D). *(Level 2)* |
+
+#### Hardware access (Level 1+)
+
+| Command | Syntax | Description |
+| ------- | ------ | ----------- |
+| `access/read` | `access/read` | Read from the hardware peripheral bus (I2C/SPI/MDIO). *(Level 1)* |
+| `access/write` | `access/write` | Write to the hardware peripheral bus. *(Level 1)* |
+| `mdio/read` | `mdio/read <phy> <reg>` | Read a PHY register via MDIO bus. Supports Clause 22 and Clause 45. *(Level 1)* |
+| `mdio/write` | `mdio/write <phy> <reg> <value>` | Write a PHY register via MDIO bus. *(Level 1)* |
+| `efuse` | `efuse` | Read and display eFuse (OTP) contents: chip MAC, serial number, manufacturing trim values. *(Level 2)* |
+| `efusebits` | `efusebits` | Display eFuse bit-level detail. *(Level 2)* |
+
+#### MACsec / EAP (Level 2)
+
+| Command | Syntax | Description |
+| ------- | ------ | ----------- |
+| `eae/eap` | `eae/eap` | Show EAP MAC address used for EAP-TLS authentication. |
+| `eae/mka` | `eae/mka` | Show MKA (MACsec Key Agreement) protocol state and MKPDU source address. |
+| `eae/mtime` | `eae/mtime` | Show MKA timing parameters (hello interval, lifetime, SAK rekey interval). |
+| `eae/klen` | `eae/klen` | Show MACsec key length config (AES-GCM-128 or AES-GCM-256). |
+
+### PON speed mode encoding
+
+| dnrate | uprate | Mode | Description |
+| ------ | ------ | ---- | ----------- |
+| 0 | 0 | 1G/1G | Standard EPON |
+| 1 | 0 | 2G/1G | Mixed mode |
+| 2 | 0 | 10G/1G | Asymmetric 10G-EPON (Free/Iliad) |
+| 2 | 1 | 10G/10G | Symmetric 10G-EPON |
+
+### `load/info` output
+
 ```
 TK2000 APP 3.27 May 13 2016 02:48:05  Chip: 4701 B2110816
 Mode: App Normal
@@ -261,8 +396,6 @@ Stream: 112 Revision: 131152
 Time: 2016-05-18 01:28:44Z
 ```
 
-`mem/rf [start address] [length]` reads bytes from data memory (DCCM/SRAM). Due to the Harvard architecture, this command cannot read firmware code (which resides in ICCM). The address space wraps every 512 kB.
-
 ## Firmware Flash Protocol
 
 The `load/rx` command accepts a firmware image over UART using a raw binary transfer (no XMODEM, no handshake):
@@ -281,7 +414,7 @@ The firmware image must be wrapped in a TKF (Teknovus) container:
 [header 39 bytes] [payload N bytes] [CRC32 4 bytes]
 ```
 
-The trailing CRC32 covers the entire header+payload (standard IEEE 802.3 CRC). The ONU writes to App 0 and App 1 slots in rotation.
+The trailing CRC32 covers the entire header+payload (standard IEEE 802.3 CRC, big-endian). The ONU writes to App 0 and App 1 slots in rotation. There is no flow control and no error correction — the UART link must be reliable.
 
 ## List of partitions
 


### PR DESCRIPTION
Adds extensive reverse-engineering findings for the Free/Iliad F-MDCONU3A
(BCM55030 10G-EPON ONU):

- **CLI permission system**: the `pl` built-in command bypasses all
  permission checks. `pl omega` gives full manufacturing access (level 2)
  from the default UART shell, no password required.
- **Complete CLI command tree** at all 3 permission levels with inline
  descriptions (~60 level 0 + ~20 level 1 + ~25 level 2 commands).
- **Full CLI command reference**: syntax, arguments, and descriptions for
  every command organized by category (system, EPON, MPCP, memory, stats,
  firmware, FDS, debug, multicast, SerDes, MACsec).
- **PON speed mode encoding** table (1G/1G, 2G/1G, 10G/1G, 10G/10G).
- **Firmware flash protocol** (`load/rx`): raw binary transfer over UART
  at 57600 baud, TKF container format with trailing CRC32.
- Hardware architecture details: Harvard ARC (ICCM/DCCM), firmware
  structure, FDS personality records.
- Expanded flash memory map with all 5 regions.
- Corrected `mcast/` subtree: `domains`/`groups`/`sources`/`reporters`
  do not exist in the v3.2.9 binary (only `igmpinfo` and `igmpsources`).

All findings are from static analysis of the v3.2.9 firmware binary in
Ghidra (2697 functions fully named). No proprietary documentation was used.
