### PR TITLE
Add FiberMall GPON-ONU-STB+ and GPON-ONU-CLB+ device pages

### DIFF
--- a/_ont/ont-fibermall-gpon-onu-clb+.md
+++ b/_ont/ont-fibermall-gpon-onu-clb+.md
@@ -124,7 +124,7 @@ Transmitter: 1310 nm DFB laser, LVPECL input (DC coupled). Receiver: 1490 nm Sup
 | 19  | TD-        | Inverted Transmit Data In (LVPECL, DC coupled)                               |
 | 20  | VeeT       | Transmitter Ground                                                           |
 
-{% include alert.html content="Note the key Pin differences vs the <a href='/ont-fibermall-gpon-onu-stb+'>STB+ (with MAC)</a>: Pin 3 is TX_Burst (burst enable) instead of TX_Disable, Pin 7 is TX_SD (transmitter signal detect) instead of Dying Gasp, and Pin 8 is RX_SD instead of LOS." alert="Note" icon="svg-info" color="blu" %}
+{% include alert.html content="Note the key Pin differences vs the <a href='/ont-fibermall-gpon-onu-stb+'>STB+ (with MAC)</a>: Pin 3 is TX_Burst (burst enable) instead of TX_Disable, Pin 7 is TX_SD (transmitter signal detect) instead of Dying Gasp, and Pin 8 is RX_SD instead of LOS." alert="Note" icon="svg-info" color="blue" %}
 
 ### EEPROM (A0h) Key Fields
 
@@ -165,7 +165,7 @@ Transmitter: 1310 nm DFB laser, LVPECL input (DC coupled). Receiver: 1490 nm Sup
 | Pin 8                | RX_SD (RX signal detect)     | LOS                                  |
 | Price                | $15.00                       | $45.00                               |
 
-{% include alert.html content="This page has been created from the vendor datasheet and product listing. Contributions with hands-on information are welcome." alert="Note" icon="svg-info" color="blu" %}
+{% include alert.html content="This page has been created from the vendor datasheet and product listing. Contributions with hands-on information are welcome." alert="Note" icon="svg-info" color="blue" %}
 
 # Miscellaneous Links
 

--- a/_ont/ont-fibermall-gpon-onu-clb+.md
+++ b/_ont/ont-fibermall-gpon-onu-clb+.md
@@ -1,0 +1,173 @@
+---
+title: FiberMall GPON-ONU-CLB+
+has_children: false
+layout: default
+parent: FiberMall
+---
+
+{% include alert.html content="This is a raw GPON ONU SFP transceiver <strong>without MAC function</strong>. It requires an external PON MAC to operate. For the ONU Stick with integrated MAC, see <a href='/ont-fibermall-gpon-onu-stb+'>FiberMall GPON-ONU-STB+</a>. See also <a href='/sfp-standard'>SFP Standard</a> and <a href='/ont-wo-mac'>SFP with PON MAC and w/o PON MAC</a> for background." alert="Warning" icon="svg-warning" color="yellow" %}
+
+# Hardware Specifications
+
+|                       |                                                                       |
+| --------------------- | --------------------------------------------------------------------- |
+| Vendor/Brand          | FiberMall                                                             |
+| Model                 | GPON-ONU-CLB+                                                         |
+| Chipset               |                                                                       |
+| Optics                | SC/UPC                                                                |
+| Form Factor           | SFP                                                                   |
+| PON MAC               | ❌ None (raw transceiver, requires external PON MAC)                  |
+
+## Product Variants
+
+| Part Number      | TX Enable | Temperature  | Price  |
+| ---------------- | --------- | ------------ | ------ |
+| GPON-ONU-CLB+    | Low level | -5 to 70°C   | $15.00 |
+| GPON-ONU-ILB+    | Low level | -40 to 85°C  |        |
+| GPON-ONU-CHB+    | High level| -5 to 70°C   |        |
+| GPON-ONU-IHB+    | High level| -40 to 85°C  |        |
+
+All variants: SFP, TX-1.244G/RX-2.488G, T1310nm/R1490nm, GPON Class B+, no MAC, DDM.
+
+## Datasheet Specifications
+
+### General
+
+|                              |                                            |
+| ---------------------------- | ------------------------------------------ |
+| TX Data Rate                 | 1.244 Gbps (burst mode)                   |
+| RX Data Rate                 | 2.488 Gbps (continuous mode)              |
+| Max Distance                 | 20 km                                      |
+| Fiber Type                   | Single Mode 9/125 µm                      |
+| Class                        | B+                                         |
+| Power Supply                 | 3.3V ± 5% (3.135–3.465V)                  |
+| Supply Current               | 300 mA max                                 |
+| Power Consumption            | 1 W                                        |
+| Operating Temperature        | -5 to 70°C (C-Temp) / -40 to 85°C (I-Temp)|
+| DDM                          | ✅ SFF-8472                                |
+
+### Transmitter Optical Characteristics
+
+| Parameter                          | Min    | Typical | Max    | Unit   |
+| ---------------------------------- | ------ | ------- | ------ | ------ |
+| Launched Power (avg.)              | +0.5   |         | +5.0   | dBm    |
+| Operating Wavelength Range         | 1260   |         | 1360   | nm     |
+| Output Spectrum Width (RMS)        |        |         | 1.0    | nm     |
+| Side Mode Suppression Ratio        | 30     |         |        | dB     |
+| Extinction Ratio                   | 9      |         |        | dB     |
+| Optical Rise Time                  |        |         | 260    | ps     |
+| Optical Fall Time                  |        |         | 260    | ps     |
+| Output Power After TX Disable      |        |         | -50    | dBm    |
+| Burst Turn-On Time                 |        |         | 12.8   | ns     |
+| Burst Turn-Off Time                |        |         | 12.8   | ns     |
+| TX Reflectance                     |        |         | -15    | dB     |
+
+### Receiver Optical Characteristics
+
+| Parameter                          | Min    | Typical | Max    | Unit   |
+| ---------------------------------- | ------ | ------- | ------ | ------ |
+| Wavelength Range                   | 1480   |         | 1500   | nm     |
+| Sensitivity (BER ≤ 10⁻¹²)         |        |         | -28    | dBm    |
+| Saturation Optical Power           | -8     |         |        | dBm    |
+| SD Assert Level                    |        |         | -29    | dBm    |
+| SD Deassert Level                  | -45    |         |        | dBm    |
+| SD Hysteresis                      | 0.5    |         | 6      | dB     |
+| Receiver Reflectance               |        |         | -12    | dB     |
+
+### Electrical Characteristics
+
+| Parameter                          | Min    | Typical | Max    | Unit   |
+| ---------------------------------- | ------ | ------- | ------ | ------ |
+| TX Differential Input Voltage      | 300    |         | 2400   | mV     |
+| RX Differential Output Voltage     | 500    |         | 1200   | mV     |
+| TX Common-Mode Input Voltage       | 1.6    |         | 2.4    | V      |
+| Input Differential Impedance       | 90     | 100     | 110    | Ω      |
+| TX Fault Output (Normal)           | 0      |         | 0.4    | V      |
+| TX Fault Output (Fault)            | 2.4    |         | VCC+0.3| V      |
+| SD Assert Time                     |        |         | 100    | µs     |
+| SD Deassert Time                   |        |         | 100    | µs     |
+
+Transmitter: 1310 nm DFB laser, LVPECL input (DC coupled). Receiver: 1490 nm Super-TIA, CML output (AC coupled).
+
+### DDM Accuracy
+
+| Parameter    | Accuracy |
+| ------------ | -------- |
+| Temperature  | ±3°C     |
+| Voltage      | ±3%      |
+| Bias Current | ±10 mA   |
+| TX Power     | ±3 dB    |
+| RX Power     | ±3 dB    |
+
+## Pin Definition
+
+| Pin | Name       | Description                                                                  |
+| --- | ---------- | ---------------------------------------------------------------------------- |
+| 1   | VeeT       | Transmitter Ground                                                           |
+| 2   | TX_Fault   | Transmitter Fault Indication (LVTTL output: low = normal, high = abnormal)   |
+| 3   | TX_Burst   | **Transmitter Burst Enable Input** (LVTTL)                                   |
+| 4   | MOD-DEF(2) | I²C Data (SDA), LVTTL                                                        |
+| 5   | MOD-DEF(1) | I²C Clock (SCL), LVTTL                                                       |
+| 6   | MOD-DEF(0) | Module Definition 0, grounded within module                                  |
+| 7   | TX_SD      | **Transmitter Signal Detect** (LVTTL output, active high)                    |
+| 8   | RX_SD      | **Receiver Signal Detect** (LVTTL output: high = signal, low = loss)         |
+| 9   | VeeR       | Receiver Ground                                                              |
+| 10  | VeeR       | Receiver Ground                                                              |
+| 11  | VeeR       | Receiver Ground                                                              |
+| 12  | RD-        | Inverted Receiver Data Out (CML, AC coupled)                                 |
+| 13  | RD+        | Receiver Data Out (CML, AC coupled)                                          |
+| 14  | VeeR       | Receiver Ground                                                              |
+| 15  | VccR       | Receiver Power                                                               |
+| 16  | VccT       | Transmitter Power                                                            |
+| 17  | VeeT       | Transmitter Ground                                                           |
+| 18  | TD+        | Transmit Data In (LVPECL, DC coupled)                                        |
+| 19  | TD-        | Inverted Transmit Data In (LVPECL, DC coupled)                               |
+| 20  | VeeT       | Transmitter Ground                                                           |
+
+{% include alert.html content="Note the key Pin differences vs the <a href='/ont-fibermall-gpon-onu-stb+'>STB+ (with MAC)</a>: Pin 3 is TX_Burst (burst enable) instead of TX_Disable, Pin 7 is TX_SD (transmitter signal detect) instead of Dying Gasp, and Pin 8 is RX_SD instead of LOS." alert="Note" icon="svg-info" color="blu" %}
+
+### EEPROM (A0h) Key Fields
+
+| Address | Field           | Value        | Description                         |
+| ------- | --------------- | ------------ | ----------------------------------- |
+| 00      | Identifier      | 03           | SFP                                 |
+| 01      | Ext. Identifier | 04           | Module soldered to motherboard      |
+| 02      | Connector       | 01           | Optical Pigtail                     |
+| 11      | Encoding        | 03           | NRZ                                 |
+| 12      | BR, Nominal     | 0C           | 1.2 Gbps                            |
+| 14      | Length (9µm km) | 14           | 20 km                               |
+| 40–55   | Vendor P/N      | GPON-ONU-xxB+| ASCII                               |
+| 60–61   | Laser Wavelength| 051E         | 1310 nm                             |
+| 92      | Diag. Mon. Type | 68           | Internal calibration, avg. power RX |
+
+## Standards Compliance
+
+- ITU-T G.984.2 (GPON)
+- SFP MSA (SFF-8074i)
+- SFF-8472 (DDM)
+- FCC 47 CFR Part 15, Class B
+- FDA 21 CFR 1040.10 and 1040.11 (Laser Notice No. 50)
+- IEC-60825 (Class 1 laser safety)
+- Telcordia GR-468-CORE
+- TR-NWT-000870 ESD Class 2
+
+## Key Differences vs STB+ (with MAC)
+
+| Feature              | CLB+ (no MAC)                | STB+ (with MAC)                      |
+| -------------------- | ---------------------------- | ------------------------------------ |
+| PON MAC              | ❌ None                      | ✅ Integrated                        |
+| Receiver Type        | Super-TIA                    | APD-TIA                              |
+| Power Consumption    | 1 W                          | 2.48 W                               |
+| GPON/EPON Dual-Mode  | ❌ GPON only                 | ✅ Auto-detect GPON/EPON             |
+| OMCI (G.988)         | ❌                           | ✅                                   |
+| Pin 3                | TX_Burst (burst enable)      | TX_Disable                           |
+| Pin 7                | TX_SD (TX signal detect)     | Dying Gasp detect                    |
+| Pin 8                | RX_SD (RX signal detect)     | LOS                                  |
+| Price                | $15.00                       | $45.00                               |
+
+{% include alert.html content="This page has been created from the vendor datasheet and product listing. Contributions with hands-on information are welcome." alert="Note" icon="svg-info" color="blu" %}
+
+# Miscellaneous Links
+
+- [FiberMall GPON-ONU-CLB+ product page](https://www.fibermall.com/sale-437481-gpon-onu-sfp-tx1310nm-class-b.htm)
+- [Datasheet (PDF)](https://www.fibermall.com/file/datasheet/gpon-onu-xxb%2B.pdf)

--- a/_ont/ont-fibermall-gpon-onu-stb+.md
+++ b/_ont/ont-fibermall-gpon-onu-stb+.md
@@ -5,7 +5,7 @@ layout: default
 parent: FiberMall
 ---
 
-{% include alert.html content="This is an ONU Stick SFP with integrated GPON MAC. For the raw SFP transceiver without MAC, see [FiberMall GPON-ONU-CLB+](/ont-fibermall-gpon-onu-clb+)." alert="Info" icon="svg-info" color="blu" %}
+{% include alert.html content="This is an ONU Stick SFP with integrated GPON MAC. For the raw SFP transceiver without MAC, see [FiberMall GPON-ONU-CLB+](/ont-fibermall-gpon-onu-clb+)." alert="Info" icon="svg-info" color="blue" %}
 
 # Hardware Specifications
 
@@ -140,7 +140,7 @@ Transmitter: 1310 nm DFB laser. Receiver: 1490 nm APD-TIA, CML output (AC couple
 - Receiver is APD-TIA based, providing higher sensitivity than the [non-MAC CLB+ variant](/ont-fibermall-gpon-onu-clb+) which uses Super-TIA.
 - This is a complete "PON on a Stick" — an entire FTTH ONU in a slightly oversized SFP that can be plugged into networking equipment (switch, router, PBX, etc.).
 
-{% include alert.html content="This page has been created from the vendor datasheet and product listing. Contributions with hands-on information (chipset identification, firmware details, serial/SSH access, IP address, web GUI, etc.) are very welcome." alert="Note" icon="svg-info" color="blu" %}
+{% include alert.html content="This page has been created from the vendor datasheet and product listing. Contributions with hands-on information (chipset identification, firmware details, serial/SSH access, IP address, web GUI, etc.) are very welcome." alert="Note" icon="svg-info" color="blue" %}
 
 # Miscellaneous Links
 

--- a/_ont/ont-fibermall-gpon-onu-stb+.md
+++ b/_ont/ont-fibermall-gpon-onu-stb+.md
@@ -5,6 +5,8 @@ layout: default
 parent: FiberMall
 ---
 
+{% include alert.html content="This is an ONU Stick SFP with integrated GPON MAC. For the raw SFP transceiver without MAC, see [FiberMall GPON-ONU-CLB+](/ont-fibermall-gpon-onu-clb+)." alert="Info" icon="svg-info" color="blu" %}
+
 # Hardware Specifications
 
 |                       |                                                                       |
@@ -24,37 +26,105 @@ parent: FiberMall
 | Serial                |                                                                       |
 | Form Factor           | miniONT SFP                                                           |
 
-## Vendor Datasheet Specifications
-
-|                              |                                        |
-| ---------------------------- | -------------------------------------- |
-| TX Data Rate                 | 1.244 Gbps                             |
-| RX Data Rate                 | 2.488 Gbps                             |
-| TX Wavelength                | 1310 nm (DFB)                          |
-| RX Wavelength                | 1490 nm (APD-TIA)                      |
-| Optical Power (TX)           | +0.5 to +5.0 dBm                      |
-| Receiver Sensitivity         | -28 dBm                                |
-| Saturation Optical Power     | -8 dBm                                 |
-| Class                        | B+                                     |
-| Max Distance                 | 20 km                                  |
-| Fiber Type                   | Single Mode (9/125 µm)                 |
-| Power Supply                 | 3.3V single supply                     |
-| Power Dissipation            | 2.48 W typical                         |
-| Operating Temperature        | 0 to 70°C (C-Temp) / -40 to 85°C (I-Temp) |
-| DDM                          | ✅ SFF-8472                            |
-
 ## Product Variants
 
-| Part Number      | Connector | Temperature | Description                                                                              |
-| ---------------- | --------- | ----------- | ---------------------------------------------------------------------------------------- |
-| GPON-ONU-STB+    | SC/UPC    | 0 to 70°C   | SFP, 1.244G/2.488G, T1310nm/R1490nm, GPON Class B+, MAC inside, RoHS 6, DDM             |
-| GPON-ONU-ISTB+   | SC/UPC    | -40 to 85°C | Industrial temperature variant                                                           |
-| GPON-ONU-STAB+   | SC/APC    | 0 to 70°C   | SFP, 1.244G/2.488G, T1310nm/R1490nm, GPON Class B+, MAC inside, RoHS 6, DDM             |
-| GPON-ONU-ISTAB+  | SC/APC    | -40 to 85°C | Industrial temperature variant                                                           |
+| Part Number      | Connector | Temperature  | Price  |
+| ---------------- | --------- | ------------ | ------ |
+| GPON-ONU-STB+    | SC/UPC    | 0 to 70°C    | $45.00 |
+| GPON-ONU-ISTB+   | SC/UPC    | -40 to 85°C  |        |
+| GPON-ONU-STAB+   | SC/APC    | 0 to 70°C    | $45.00 |
+| GPON-ONU-ISTAB+  | SC/APC    | -40 to 85°C  |        |
+
+All variants: SFP, TX-1.244G/RX-2.488G, T1310nm/R1490nm, GPON Class B+, MAC inside, RoHS 6, DDM.
+
+## Datasheet Specifications
+
+### General
+
+|                              |                                            |
+| ---------------------------- | ------------------------------------------ |
+| TX Data Rate                 | 1.244 Gbps (burst mode)                   |
+| RX Data Rate                 | 2.488 Gbps (continuous mode)              |
+| Max Distance                 | 20 km                                      |
+| Fiber Type                   | Single Mode 9/125 µm                      |
+| Class                        | B+                                         |
+| Power Supply                 | 3.3V ± 5% (3.13–3.47V)                    |
+| Power Dissipation            | 2.48 W typical                             |
+| Operating Temperature        | 0 to 70°C (C-Temp) / -40 to 85°C (I-Temp) |
+| DDM                          | ✅ SFF-8472 v9.5                           |
+
+### Transmitter Optical Characteristics
+
+| Parameter                          | Min    | Typical | Max    | Unit   |
+| ---------------------------------- | ------ | ------- | ------ | ------ |
+| Centre Wavelength                  | 1290   |         | 1330   | nm     |
+| Side Mode Suppression Ratio        | 30     |         |        | dB     |
+| Optical Spectrum Width (RMS)       |        |         | 1      | nm     |
+| Average Launch Power               | +0.5   |         | +5.0   | dBm    |
+| Power-OFF TX Optical Power         |        |         | -45    | dBm    |
+| Extinction Ratio                   | 9      |         |        | dB     |
+| Rise/Fall Time (20%-80%)           |        |         | 260    | ps     |
+| Burst Turn-On Time                 |        |         | 12.8   | ns     |
+| Burst Turn-Off Time                |        |         | 12.8   | ns     |
+| RIN15 OMA                          |        |         | -115   | dB/Hz  |
+| Optical Return Loss Tolerance      | 15     |         |        | dB     |
+| TX Reflectance                     |        |         | -6     | dB     |
+| TX and Dispersion Penalty          |        |         | 2      | dB     |
+
+### Receiver Optical Characteristics
+
+| Parameter                          | Min    | Typical | Max    | Unit   |
+| ---------------------------------- | ------ | ------- | ------ | ------ |
+| Operating Wavelength               | 1480   | 1490    | 1500   | nm     |
+| Sensitivity (BER 10⁻¹²)           |        |         | -28    | dBm    |
+| Saturation Optical Power           | -8     |         |        | dBm    |
+| LOS Deassert Level                 |        |         | -29    | dBm    |
+| LOS Assert Level                   | -40    |         |        | dBm    |
+| LOS Hysteresis                     | 0.5    |         | 5      | dB     |
+| Receiver Reflectance               |        |         | -20    | dB     |
+| WDM Filter Isolation (1550 nm)     | 38     |         |        | dB     |
+| WDM Filter Isolation (1650 nm)     | 35     |         |        | dB     |
+
+### Electrical Characteristics
+
+| Parameter                          | Min    | Typical | Max    | Unit   |
+| ---------------------------------- | ------ | ------- | ------ | ------ |
+| Data Input Differential Swing      | 300    |         | 1600   | mV     |
+| Data Output Differential Swing     | 300    |         | 1200   | mV     |
+| Input Differential Impedance       | 90     | 100     | 110    | Ω      |
+| TX Disable Voltage (Enable)        | 0      |         | 0.8    | V      |
+| TX Disable Voltage (Disable)       | 2.0    |         | VCC    | V      |
+
+Transmitter: 1310 nm DFB laser. Receiver: 1490 nm APD-TIA, CML output (AC coupled).
+
+## Pin Definition
+
+| Pin | Name       | Description                                                            |
+| --- | ---------- | ---------------------------------------------------------------------- |
+| 1   | VeeT       | Transmitter Ground                                                     |
+| 2   | TX Fault   | Transmitter Fault Indication (LVTTL output: low = normal, high = fault)|
+| 3   | TX Disable | Transmitter Disable; turns off transmitter laser output                |
+| 4   | MOD-DEF(2) | SDA I²C Data line                                                      |
+| 5   | MOD-DEF(1) | SCL I²C Clock line                                                     |
+| 6   | MOD-DEF(0) | Module Absent, connected to VeeR                                       |
+| 7   | RateSelect | **Dying Gasp detect** (input, active low)                              |
+| 8   | LOS        | Loss of Signal                                                         |
+| 9   | VeeR       | Receiver Ground                                                        |
+| 10  | VeeR       | Receiver Ground                                                        |
+| 11  | VeeR       | Receiver Ground                                                        |
+| 12  | RD-        | Inverted Received Data Output                                          |
+| 13  | RD+        | Received Data Output                                                   |
+| 14  | VeeR       | Receiver Ground                                                        |
+| 15  | VccR       | Receiver Power                                                         |
+| 16  | VccT       | Transmitter Power                                                      |
+| 17  | VeeT       | Transmitter Ground                                                     |
+| 18  | TD+        | Transmit Data In                                                       |
+| 19  | TD-        | Inverted Transmit Data In                                              |
+| 20  | VeeT       | Transmitter Ground                                                     |
 
 ## Standards Compliance
 
-- ITU-T G.984.2 / G.984.2 Amendment 1
+- ITU-T G.984.2 / G.984.2 Amendment 1 (GPON)
 - ITU-T G.988 (OMCI)
 - SFP MSA (SFF-8074i)
 - SFF-8472 v9.5 (DDM)
@@ -64,10 +134,13 @@ parent: FiberMall
 
 ## Notes
 
-- The GPON-ONU-STB+ is described as a dual-mode ONU stick: it supports both GPON and EPON ONU OAM and will automatically establish a link with either a GPON OLT or EPON OLT.
-- Pin 7 (RateSelect) is repurposed for Dying Gasp detection (input, active low).
+- The GPON-ONU-STB+ is described as a **dual-mode ONU stick**: it supports both GPON and EPON ONU OAM and will automatically establish a link with either a GPON OLT or EPON OLT.
+- Pin 7 (RateSelect) is repurposed for **Dying Gasp detection** (input, active low).
+- Data input is LVPECL compatible, DC coupled internally.
+- Receiver is APD-TIA based, providing higher sensitivity than the [non-MAC CLB+ variant](/ont-fibermall-gpon-onu-clb+) which uses Super-TIA.
+- This is a complete "PON on a Stick" — an entire FTTH ONU in a slightly oversized SFP that can be plugged into networking equipment (switch, router, PBX, etc.).
 
-{% include alert.html content="This page has been created from the vendor datasheet and product listing only. Contributions with hands-on information (chipset identification, firmware details, serial/SSH access, IP address, web GUI, etc.) are very welcome." alert="Note" icon="svg-info" color="blu" %}
+{% include alert.html content="This page has been created from the vendor datasheet and product listing. Contributions with hands-on information (chipset identification, firmware details, serial/SSH access, IP address, web GUI, etc.) are very welcome." alert="Note" icon="svg-info" color="blu" %}
 
 # Miscellaneous Links
 

--- a/_ont/ont-fibermall-gpon-onu-stb+.md
+++ b/_ont/ont-fibermall-gpon-onu-stb+.md
@@ -1,0 +1,76 @@
+---
+title: FiberMall GPON-ONU-STB+
+has_children: false
+layout: default
+parent: FiberMall
+---
+
+# Hardware Specifications
+
+|                       |                                                                       |
+| --------------------- | --------------------------------------------------------------------- |
+| Vendor/Brand          | FiberMall                                                             |
+| Model                 | GPON-ONU-STB+ (SC/UPC) / GPON-ONU-STAB+ (SC/APC)                    |
+| Chipset               | Unknown                                                               |
+| Flash                 |                                                                       |
+| RAM                   |                                                                       |
+| System                |                                                                       |
+| HSGMII                |                                                                       |
+| Optics                | SC/UPC or SC/APC                                                      |
+| IP address            |                                                                       |
+| Web Gui               |                                                                       |
+| SSH                   |                                                                       |
+| Telnet                |                                                                       |
+| Serial                |                                                                       |
+| Form Factor           | miniONT SFP                                                           |
+
+## Vendor Datasheet Specifications
+
+|                              |                                        |
+| ---------------------------- | -------------------------------------- |
+| TX Data Rate                 | 1.244 Gbps                             |
+| RX Data Rate                 | 2.488 Gbps                             |
+| TX Wavelength                | 1310 nm (DFB)                          |
+| RX Wavelength                | 1490 nm (APD-TIA)                      |
+| Optical Power (TX)           | +0.5 to +5.0 dBm                      |
+| Receiver Sensitivity         | -28 dBm                                |
+| Saturation Optical Power     | -8 dBm                                 |
+| Class                        | B+                                     |
+| Max Distance                 | 20 km                                  |
+| Fiber Type                   | Single Mode (9/125 µm)                 |
+| Power Supply                 | 3.3V single supply                     |
+| Power Dissipation            | 2.48 W typical                         |
+| Operating Temperature        | 0 to 70°C (C-Temp) / -40 to 85°C (I-Temp) |
+| DDM                          | ✅ SFF-8472                            |
+
+## Product Variants
+
+| Part Number      | Connector | Temperature | Description                                                                              |
+| ---------------- | --------- | ----------- | ---------------------------------------------------------------------------------------- |
+| GPON-ONU-STB+    | SC/UPC    | 0 to 70°C   | SFP, 1.244G/2.488G, T1310nm/R1490nm, GPON Class B+, MAC inside, RoHS 6, DDM             |
+| GPON-ONU-ISTB+   | SC/UPC    | -40 to 85°C | Industrial temperature variant                                                           |
+| GPON-ONU-STAB+   | SC/APC    | 0 to 70°C   | SFP, 1.244G/2.488G, T1310nm/R1490nm, GPON Class B+, MAC inside, RoHS 6, DDM             |
+| GPON-ONU-ISTAB+  | SC/APC    | -40 to 85°C | Industrial temperature variant                                                           |
+
+## Standards Compliance
+
+- ITU-T G.984.2 / G.984.2 Amendment 1
+- ITU-T G.988 (OMCI)
+- SFP MSA (SFF-8074i)
+- SFF-8472 v9.5 (DDM)
+- FCC 47 CFR Part 15, Class B
+- FDA 21 CFR 1040.10 and 1040.11
+- IEC-60825 (Class 1 laser safety)
+
+## Notes
+
+- The GPON-ONU-STB+ is described as a dual-mode ONU stick: it supports both GPON and EPON ONU OAM and will automatically establish a link with either a GPON OLT or EPON OLT.
+- Pin 7 (RateSelect) is repurposed for Dying Gasp detection (input, active low).
+
+{% include alert.html content="This page has been created from the vendor datasheet and product listing only. Contributions with hands-on information (chipset identification, firmware details, serial/SSH access, IP address, web GUI, etc.) are very welcome." alert="Note" icon="svg-info" color="blu" %}
+
+# Miscellaneous Links
+
+- [FiberMall GPON-ONU-STAB+ product page (SC/APC)](https://www.fibermall.com/sale-462750-gpon-onu-sticak-sfp-class-b-apc.htm)
+- [FiberMall GPON-ONU-STB+ product page (SC/UPC)](https://www.fibermall.com/sale-437801-gpon-onu-sticak-sfp-class-b.htm)
+- [Datasheet (PDF)](https://www.fibermall.com/file/datasheet/gpon-onu-stb%2B.pdf)

--- a/_ont/ont-fibermall.md
+++ b/_ont/ont-fibermall.md
@@ -1,0 +1,5 @@
+---
+title: FiberMall
+has_children: true
+layout: default
+---


### PR DESCRIPTION
## Summary

Adds a new **FiberMall** vendor section with two device pages covering the full FiberMall GPON ONU SFP product line.

### New files
- `_ont/ont-fibermall.md` — vendor parent page
- `_ont/ont-fibermall-gpon-onu-stb+.md` — ONU Stick **with MAC** (STB+/STAB+/ISTB+/ISTAB+)
- `_ont/ont-fibermall-gpon-onu-clb+.md` — raw SFP transceiver **without MAC** (CLB+/ILB+/CHB+/IHB+)

### Content sourced from
- [FiberMall GPON-ONU-STAB+ product page (SC/APC)](https://www.fibermall.com/sale-462750-gpon-onu-sticak-sfp-class-b-apc.htm)
- [FiberMall GPON-ONU-STB+ product page (SC/UPC)](https://www.fibermall.com/sale-437801-gpon-onu-sticak-sfp-class-b.htm)
- [FiberMall GPON-ONU-CLB+ product page (no MAC)](https://www.fibermall.com/sale-437481-gpon-onu-sfp-tx1310nm-class-b.htm)
- Vendor datasheets: `GPON-ONU-STB+.pdf` and `GPON-ONU-xxB+.pdf`

### Details included
- **STB+ (with MAC)**: full TX/RX optical characteristic tables, electrical characteristics, 20-pin definition, product variants with pricing, dual-mode GPON/EPON auto-detect, standards compliance, cross-links to CLB+
- **CLB+ (no MAC)**: full TX/RX optical tables, electrical characteristics, pin definitions (highlighting differences vs STB+ — TX_Burst vs TX_Disable, TX_SD vs Dying Gasp), EEPROM key fields, DDM accuracy, comparison table vs STB+, clear warning about requiring external PON MAC

Both pages include alerts inviting hands-on contributions (chipset ID, firmware, serial/SSH access, etc.).