### PR TITLE
Add Ubiquiti UFiber ONT pages: WaveFiber ONU, Nano, Loco

### DIFF
--- a/_ont/ont-ufiber-uf-loco.md
+++ b/_ont/ont-ufiber-uf-loco.md
@@ -1,0 +1,39 @@
+---
+title: UFiber Loco
+has_children: false
+layout: default
+parent: UFiber
+---
+
+{% include alert.html content="This device is designed to be used with the Ubiquiti Fiber OLT. Third-party OLTs may be incompatible or may not reliably connect to the ONU." alert="Warning" icon="svg-warning" color="red" %}
+
+# Hardware Specifications
+
+|              |                                          |
+| ------------ | ---------------------------------------- |
+| Vendor/Brand | UFiber                                   |
+| Model        | UF-LOCO                                  |
+| Chipset      |                                          |
+| Flash        |                                          |
+| RAM          |                                          |
+| System       |                                          |
+| Optics       | SC/APC                                   |
+| IP address   |                                          |
+| Web Gui      | ✅                                       |
+| SSH          |                                          |
+| Telnet       | ✅                                       |
+| Serial       |                                          |
+| Form Factor  | ONT                                      |
+
+## Serial
+
+## Root procedure
+
+## Firmware is interchangeable with
+
+## List of software versions
+
+## Miscellaneous Links
+
+- [Ubiquiti Store Page](https://store.ui.com/us/en/category/fiber-gpon/products/ufiber-loco)
+- [Installation Guide](https://ui.com/qig/uf-loco)

--- a/_ont/ont-ufiber-uf-nano.md
+++ b/_ont/ont-ufiber-uf-nano.md
@@ -1,0 +1,39 @@
+---
+title: UFiber Nano
+has_children: false
+layout: default
+parent: UFiber
+---
+
+{% include alert.html content="This device is designed to be used with the Ubiquiti Fiber OLT. Third-party OLTs may be incompatible or may not reliably connect to the ONU." alert="Warning" icon="svg-warning" color="red" %}
+
+# Hardware Specifications
+
+|              |                                          |
+| ------------ | ---------------------------------------- |
+| Vendor/Brand | UFiber                                   |
+| Model        | UF-Nano                                  |
+| Chipset      |                                          |
+| Flash        |                                          |
+| RAM          |                                          |
+| System       |                                          |
+| Optics       | SC/APC                                   |
+| IP address   |                                          |
+| Web Gui      | ✅                                       |
+| SSH          |                                          |
+| Telnet       | ✅                                       |
+| Serial       |                                          |
+| Form Factor  | ONT                                      |
+
+## Serial
+
+## Root procedure
+
+## Firmware is interchangeable with
+
+## List of software versions
+
+## Miscellaneous Links
+
+- [Ubiquiti Store Page](https://store.ui.com/us/en/category/fiber-gpon/products/uf-nano)
+- [Installation Guide](https://ui.com/qig/uf-nano)

--- a/_ont/ont-ufiber-wave-fiber-onu.md
+++ b/_ont/ont-ufiber-wave-fiber-onu.md
@@ -1,0 +1,38 @@
+---
+title: UFiber WaveFiber ONU
+has_children: false
+layout: default
+parent: UFiber
+---
+
+# Hardware Specifications
+
+|              |                                          |
+| ------------ | ---------------------------------------- |
+| Vendor/Brand | UFiber                                   |
+| Model        | WaveFiber ONU                            |
+| Chipset      |                                          |
+| Flash        |                                          |
+| RAM          |                                          |
+| System       |                                          |
+| 2.5GBaseT    | Yes                                      |
+| Optics       | SC/APC                                   |
+| IP address   |                                          |
+| Web Gui      | ✅                                       |
+| SSH          |                                          |
+| Telnet       | ✅                                       |
+| Serial       |                                          |
+| Form Factor  | ONT                                      |
+
+## Serial
+
+## Root procedure
+
+## Firmware is interchangeable with
+
+## List of software versions
+
+## Miscellaneous Links
+
+- [Ubiquiti Store Page](https://store.ui.com/us/en/category/fiber-gpon/products/wave-fiber-onu)
+- [Installation Guide](https://dl.ui.com/qig/wave-fiber-onu/#index)


### PR DESCRIPTION
Adds device pages for three Ubiquiti UFiber GPON ONTs under the existing UFiber parent:

- **WaveFiber ONU** — 2.5GbE GPON ONU, SC/APC, 20km reach, 5W, TX 0.5–5 dBm
- **UF-Nano** — GbE GPON CPE with LED display, wide temp range (-40 to 55°C), PoE powered
- **UF-Loco** — Ultra-low-power GPON CPE (3.5W), Micro-USB or PoE powered

Both Nano and Loco include a warning about third-party OLT compatibility issues (Ubiquiti states they may not work reliably with non-Ubiquiti OLTs).

Chipset, flash, RAM, root procedure, and serial details are left blank — these aren't available from Ubiquiti's store pages and need community contribution from teardowns.

OLTs and WiFi CPEs were intentionally excluded as not relevant to GPON hacking.