### PR TITLE
Add stub pages for UK-deployed GPON ONTs

### DIFF
--- a/_ont/ont-adtran-sdx-621i.md
+++ b/_ont/ont-adtran-sdx-621i.md
@@ -1,0 +1,35 @@
+---
+title: Adtran SDX 621i
+has_children: false
+layout: default
+parent: Adtran
+---
+
+# Hardware Specifications
+
+|                 |                                  |
+| --------------- | -------------------------------- |
+| Vendor/Brand    | Adtran                           |
+| Model           | SDX 621i                         |
+| Chipset         |                                  |
+| Flash           |                                  |
+| RAM             |                                  |
+| System          |                                  |
+| 2.5GBaseT       | No                               |
+| Optics          | SC/APC                           |
+| IP address      |                                  |
+| Web Gui         |                                  |
+| SSH             |                                  |
+| Telnet          |                                  |
+| Serial          |                                  |
+| Serial baud     |                                  |
+| Serial encoding |                                  |
+| Form Factor     | ONT                              |
+
+## List of software versions
+
+## List of partitions
+
+# Miscellaneous Links
+
+- [Adtran SDX series](https://www.adtran.com/solutions/by-segment/products/by-category/fiber-access/optical-network-terminals-ont)

--- a/_ont/ont-calix-801gt.md
+++ b/_ont/ont-calix-801gt.md
@@ -1,0 +1,35 @@
+---
+title: Calix 801GT
+has_children: false
+layout: default
+parent: Calix
+---
+
+# Hardware Specifications
+
+|                 |                                  |
+| --------------- | -------------------------------- |
+| Vendor/Brand    | Calix                            |
+| Model           | 801GT                            |
+| Chipset         |                                  |
+| Flash           |                                  |
+| RAM             |                                  |
+| System          |                                  |
+| 2.5GBaseT       | No                               |
+| Optics          | SC/APC                           |
+| IP address      |                                  |
+| Web Gui         |                                  |
+| SSH             |                                  |
+| Telnet          |                                  |
+| Serial          |                                  |
+| Serial baud     |                                  |
+| Serial encoding |                                  |
+| Form Factor     | ONT                              |
+
+## List of software versions
+
+## List of partitions
+
+# Miscellaneous Links
+
+- [Calix GigaPoint ONTs](https://www.calix.com/platforms/premises-systems.html)

--- a/_ont/ont-calix-801gv2.md
+++ b/_ont/ont-calix-801gv2.md
@@ -1,0 +1,35 @@
+---
+title: Calix GigaPoint 801Gv2
+has_children: false
+layout: default
+parent: Calix
+---
+
+# Hardware Specifications
+
+|                 |                                  |
+| --------------- | -------------------------------- |
+| Vendor/Brand    | Calix                            |
+| Model           | GigaPoint 801Gv2                 |
+| Chipset         |                                  |
+| Flash           |                                  |
+| RAM             |                                  |
+| System          |                                  |
+| 2.5GBaseT       | No                               |
+| Optics          | SC/APC                           |
+| IP address      |                                  |
+| Web Gui         |                                  |
+| SSH             |                                  |
+| Telnet          |                                  |
+| Serial          |                                  |
+| Serial baud     |                                  |
+| Serial encoding |                                  |
+| Form Factor     | ONT                              |
+
+## List of software versions
+
+## List of partitions
+
+# Miscellaneous Links
+
+- [Calix GigaPoint ONTs](https://www.calix.com/platforms/premises-systems.html)

--- a/_ont/ont-calix-gp1000g.md
+++ b/_ont/ont-calix-gp1000g.md
@@ -1,0 +1,35 @@
+---
+title: Calix GP1000g
+has_children: false
+layout: default
+parent: Calix
+---
+
+# Hardware Specifications
+
+|                 |                                  |
+| --------------- | -------------------------------- |
+| Vendor/Brand    | Calix                            |
+| Model           | GP1000g                          |
+| Chipset         |                                  |
+| Flash           |                                  |
+| RAM             |                                  |
+| System          |                                  |
+| 2.5GBaseT       | No                               |
+| Optics          | SC/APC                           |
+| IP address      |                                  |
+| Web Gui         |                                  |
+| SSH             |                                  |
+| Telnet          |                                  |
+| Serial          |                                  |
+| Serial baud     |                                  |
+| Serial encoding |                                  |
+| Form Factor     | ONT                              |
+
+## List of software versions
+
+## List of partitions
+
+# Miscellaneous Links
+
+- [Calix GigaPoint ONTs](https://www.calix.com/platforms/premises-systems.html)

--- a/_ont/ont-calix-gp1100g.md
+++ b/_ont/ont-calix-gp1100g.md
@@ -1,0 +1,35 @@
+---
+title: Calix GP1100G
+has_children: false
+layout: default
+parent: Calix
+---
+
+# Hardware Specifications
+
+|                 |                                  |
+| --------------- | -------------------------------- |
+| Vendor/Brand    | Calix                            |
+| Model           | GP1100G                          |
+| Chipset         |                                  |
+| Flash           |                                  |
+| RAM             |                                  |
+| System          |                                  |
+| 2.5GBaseT       | No                               |
+| Optics          | SC/APC                           |
+| IP address      |                                  |
+| Web Gui         |                                  |
+| SSH             |                                  |
+| Telnet          |                                  |
+| Serial          |                                  |
+| Serial baud     |                                  |
+| Serial encoding |                                  |
+| Form Factor     | ONT                              |
+
+## List of software versions
+
+## List of partitions
+
+# Miscellaneous Links
+
+- [Calix GigaPoint ONTs](https://www.calix.com/platforms/premises-systems.html)

--- a/_ont/ont-calix.md
+++ b/_ont/ont-calix.md
@@ -1,0 +1,5 @@
+---
+title: Calix
+has_children: true
+layout: default
+---

--- a/_ont/ont-huawei-hg8110h.md
+++ b/_ont/ont-huawei-hg8110h.md
@@ -1,0 +1,35 @@
+---
+title: Huawei HG8110H
+has_children: false
+layout: default
+parent: Huawei
+---
+
+# Hardware Specifications
+
+|                 |                                  |
+| --------------- | -------------------------------- |
+| Vendor/Brand    | Huawei                           |
+| Model           | HG8110H                          |
+| Chipset         |                                  |
+| Flash           |                                  |
+| RAM             |                                  |
+| System          |                                  |
+| 2.5GBaseT       | No                               |
+| Optics          | SC/APC                           |
+| IP address      |                                  |
+| Web Gui         |                                  |
+| SSH             |                                  |
+| Telnet          |                                  |
+| Serial          |                                  |
+| Serial baud     |                                  |
+| Serial encoding |                                  |
+| Form Factor     | ONT                              |
+
+## List of software versions
+
+## List of partitions
+
+# Miscellaneous Links
+
+- [Openreach FTTP deployment](https://www.openreach.com/fibre-broadband)

--- a/_ont/ont-huawei-hg8240h.md
+++ b/_ont/ont-huawei-hg8240h.md
@@ -1,0 +1,35 @@
+---
+title: Huawei HG8240H
+has_children: false
+layout: default
+parent: Huawei
+---
+
+# Hardware Specifications
+
+|                 |                                  |
+| --------------- | -------------------------------- |
+| Vendor/Brand    | Huawei                           |
+| Model           | HG8240H                          |
+| Chipset         |                                  |
+| Flash           |                                  |
+| RAM             |                                  |
+| System          |                                  |
+| 2.5GBaseT       | No                               |
+| Optics          | SC/APC                           |
+| IP address      |                                  |
+| Web Gui         |                                  |
+| SSH             |                                  |
+| Telnet          |                                  |
+| Serial          |                                  |
+| Serial baud     |                                  |
+| Serial encoding |                                  |
+| Form Factor     | ONT                              |
+
+## List of software versions
+
+## List of partitions
+
+# Miscellaneous Links
+
+- [Openreach FTTP deployment](https://www.openreach.com/fibre-broadband)

--- a/_ont/ont-kaon-pg1892g.md
+++ b/_ont/ont-kaon-pg1892g.md
@@ -1,0 +1,35 @@
+---
+title: KAON PG1892G
+has_children: false
+layout: default
+parent: KAON
+---
+
+# Hardware Specifications
+
+|                 |                                  |
+| --------------- | -------------------------------- |
+| Vendor/Brand    | KAON                             |
+| Model           | PG1892G                          |
+| Chipset         |                                  |
+| Flash           |                                  |
+| RAM             |                                  |
+| System          |                                  |
+| 2.5GBaseT       | No                               |
+| Optics          | SC/APC                           |
+| IP address      |                                  |
+| Web Gui         |                                  |
+| SSH             |                                  |
+| Telnet          |                                  |
+| Serial          |                                  |
+| Serial baud     |                                  |
+| Serial encoding |                                  |
+| Form Factor     | ONT                              |
+
+## List of software versions
+
+## List of partitions
+
+# Miscellaneous Links
+
+- [KCOM Full Fibre](https://www.kcom.com/)

--- a/_ont/ont-kaon.md
+++ b/_ont/ont-kaon.md
@@ -1,0 +1,5 @@
+---
+title: KAON
+has_children: true
+layout: default
+---

--- a/_ont/ont-zyxel-pmg1005-t20b.md
+++ b/_ont/ont-zyxel-pmg1005-t20b.md
@@ -1,0 +1,35 @@
+---
+title: Zyxel PMG1005-T20B
+has_children: false
+layout: default
+parent: Zyxel
+---
+
+# Hardware Specifications
+
+|                 |                                  |
+| --------------- | -------------------------------- |
+| Vendor/Brand    | Zyxel                            |
+| Model           | PMG1005-T20B                     |
+| Chipset         |                                  |
+| Flash           |                                  |
+| RAM             |                                  |
+| System          |                                  |
+| 2.5GBaseT       | No                               |
+| Optics          | SC/APC                           |
+| IP address      |                                  |
+| Web Gui         |                                  |
+| SSH             |                                  |
+| Telnet          |                                  |
+| Serial          |                                  |
+| Serial baud     |                                  |
+| Serial encoding |                                  |
+| Form Factor     | ONT                              |
+
+## List of software versions
+
+## List of partitions
+
+# Miscellaneous Links
+
+- [Openreach FTTP deployment](https://www.openreach.com/fibre-broadband)

--- a/_ont/ont-zyxel-pmg5318.md
+++ b/_ont/ont-zyxel-pmg5318.md
@@ -1,0 +1,35 @@
+---
+title: Zyxel PMG5318
+has_children: false
+layout: default
+parent: Zyxel
+---
+
+# Hardware Specifications
+
+|                 |                                  |
+| --------------- | -------------------------------- |
+| Vendor/Brand    | Zyxel                            |
+| Model           | PMG5318                          |
+| Chipset         |                                  |
+| Flash           |                                  |
+| RAM             |                                  |
+| System          |                                  |
+| 2.5GBaseT       | No                               |
+| Optics          | SC/APC                           |
+| IP address      |                                  |
+| Web Gui         |                                  |
+| SSH             |                                  |
+| Telnet          |                                  |
+| Serial          |                                  |
+| Serial baud     |                                  |
+| Serial encoding |                                  |
+| Form Factor     | ONT                              |
+
+## List of software versions
+
+## List of partitions
+
+# Miscellaneous Links
+
+- [B4RN Community Broadband](https://b4rn.org.uk/)


### PR DESCRIPTION
## Summary

Adds 12 new ONT stub pages for GPON devices deployed by UK ISPs/infrastructure builders that are currently missing from hack-gpon.

## New device pages

### Parent pages
- **Calix** — new vendor parent
- **KAON** — new vendor parent

### Device stubs
| Device | UK Operator |
|---|---|
| Huawei HG8110H | Openreach |
| Huawei HG8240H | Openreach |
| Zyxel PMG1005-T20B | Openreach |
| Zyxel PMG5318 | B4RN |
| Adtran SDX 621i | Community Fibre |
| Calix 801GT | CityFibre |
| Calix GigaPoint 801Gv2 | CityFibre |
| Calix GP1000g | CityFibre |
| Calix GP1100G | Community Fibre |
| KAON PG1892G | KCOM |

## Template compliance

All stubs follow `_ont/ont-template.md`:
- Hardware Specifications as top-level heading with full field set including Serial baud / Serial encoding
- List of software versions and List of partitions scaffold sections
- Miscellaneous Links as top-level heading with vendor/operator reference links
- Standard front matter (`title`, `has_children: false`, `layout: default`, `parent`)

These are intentionally minimal stubs — hardware specs, firmware versions, root procedures, etc. to be filled in by the community as information becomes available.