### PR TITLE
molex-ont: remove dead EasyEDA link + add prebuilt (no-soldering) option

### DIFF
--- a/_tools/molex-ont.md
+++ b/_tools/molex-ont.md
@@ -8,6 +8,7 @@ layout: default
 In some sticks, such as those based on Lantiq chipsets, the serial interface is exposed in the upper pins of the ONT, in order to read them there are two possibilities:
 - the use of an SFP molex ([farnell](https://it.farnell.com/en-IT/molex/74441-0001/connector-sfp-rcpt-20pos-smt/dp/2112385)) to which four wires are to be soldered and the other pins removed. This makes the adapter compatible with a single serial combination.
 - the use of a board to which the SFP molex is soldered, exposing the main SFP pins.
+- a ready-made breakout board that already exposes all 20 SFP pins on 2.54 mm headers, if you'd rather not solder an SMD Molex connector yourself (see below).
 
 {% include image.html file="ma5671a-root-1.jpg"  alt="Example of how the SFP-TTL adapter is to be connected" caption="Example of how the SFP-TTL adapter is to be connected" %}
 
@@ -22,4 +23,10 @@ the components to be soldered are instead:
 - 1x MOLEX SFP (like Molex-744410001 [lcsc](https://www.lcsc.com/product-detail/Card-Edge-Connectors_MOLEX-744410001_C277615.html), [farnell](https://it.farnell.com/en-IT/molex/74441-0001/connector-sfp-rcpt-20pos-smt/dp/2112385))
 - 2x pinout 2x10 (like [MINTRON MTP125-1210S1](https://www.lcsc.com/product-detail/Pin-Header-Female-Header_MINTRON-MTP125-1210S1_C358699.html))
 
-[Example of the final board](https://oshwlab.com/user4091049/sfp-to-ttl-v1) with these components on the EasyEDA platform.
+## Prebuilt board (no soldering)
+
+If you'd rather not solder an SMD Molex connector, a prebuilt and tested board is also available. It exposes all 20 SFP pins on 2.54 mm headers with RX/TX silkscreen, so you slot the module in and connect your USB-TTL adapter — no soldering required.
+
+![Prebuilt SFP-to-TTL adapter (v1.2), all 20 pins broken out to 2.54 mm headers](https://tvi.al/content/images/size/w960/2025/12/sfp-to-ttl-v1.2.png)
+
+[SFP-to-TTL Adapter](https://tvi.al/sfp-to-ttl-adapter/) — ships worldwide.


### PR DESCRIPTION
This PR cleans up the Molex ONT page:

- removes the dead "Example of the final board" EasyEDA link — the OSHWLab project is offline;
- adds a short **"Prebuilt board (no soldering)"** note for readers who would rather not solder an SMD Molex connector, with a hot-linked photo (no binary added to the repo) and a link to a ready-made, tested board that breaks all 20 SFP pins out to 2.54 mm headers.

**Disclosure:** I'm the maker of the linked prebuilt board, so I have a conflict of interest here. The board is an independent redesign inspired by information found on this page. The pinout/method works with any breakout — please feel free to reword it, make it vendor-neutral, or drop the prebuilt link entirely if it reads too commercial.
